### PR TITLE
Fmri merge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ install:
     - pip install networkx
     - pip install multiprocessing
     - pip install pyvtk
+    - pip install plotly==1.12
     - pip install .
 script:
     - coverage run -m unittest discover

--- a/ndmg/__init__.py
+++ b/ndmg/__init__.py
@@ -7,7 +7,7 @@ from .track.track import track as track
 from .stats import *
 # from .preproc.preproc import preproc as preproc
 from .utils.utils import utils as utils
-from .timeseries import timeeseries as timeseries
+from .timeseries import timeseries as timeseries
 from .scripts import ndmg_pipeline as ndmg_pipeline
 from .scripts import fngs_pipeline as fngs_pipeline
 

--- a/ndmg/__init__.py
+++ b/ndmg/__init__.py
@@ -2,11 +2,11 @@ from . import *
 
 # so we don't have to type ndg.graph.graph(), etc., to get the classes
 from .graph.graph import graph as graph
+from .utils.utils import utils as utils
 from .register.register import register as register
 from .track.track import track as track
 from .stats import *
 # from .preproc.preproc import preproc as preproc
-from .utils.utils import utils as utils
 from .timeseries import timeseries as timeseries
 from .scripts import ndmg_pipeline as ndmg_pipeline
 from .scripts import fngs_pipeline as fngs_pipeline

--- a/ndmg/__init__.py
+++ b/ndmg/__init__.py
@@ -7,6 +7,8 @@ from .track.track import track as track
 from .stats import *
 # from .preproc.preproc import preproc as preproc
 from .utils.utils import utils as utils
+from .timeseries import timeeseries as timeseries
 from .scripts import ndmg_pipeline as ndmg_pipeline
+from .scripts import fngs_pipeline as fngs_pipeline
 
 version = "0.0.48-1"

--- a/ndmg/graph/graph.py
+++ b/ndmg/graph/graph.py
@@ -31,7 +31,7 @@ import time
 
 
 class graph(object):
-    def __init__(self, N, rois, attr=None):
+    def __init__(self, N, rois, attr=None, sens="Diffusion MRI"):
         """
         Initializes the graph with nodes corresponding to the number of ROIs
 
@@ -59,7 +59,7 @@ class graph(object):
                           date=time.asctime(time.localtime()),
                           source="http://m2g.io",
                           region="brain",
-                          sensor="Diffusion MRI",
+                          sensor=sens,
                           ecount=0,
                           vcount=len(n_ids)
                           )

--- a/ndmg/graph/graph.py
+++ b/ndmg/graph/graph.py
@@ -107,6 +107,33 @@ class graph(object):
         self.g.add_weighted_edges_from(edge_list)
         pass
 
+    def cor_graph(self, timeseries, attr=None):
+        """
+        Takes timeseries and produces a correlation matrix
+
+        **Positional Arguments:**
+            timeseries:
+                -the timeseries file to extract correlation for.
+                          dimensions are [numrois]x[numtimesteps]
+        """
+        print ("Estimating correlation matrix for " + str(self.N) +
+              " roi graph...")
+        cor = np.corrcoef(timeseries)  # calculate pearson correlation
+
+        roilist = np.unique(self.rois)
+        roilist = roilist[roilist != 0]
+        roilist = np.sort(roilist)
+
+        for (idx_out, roi_out) in enumerate(roilist):
+            for (idx_in, roi_in) in enumerate(roilist):
+                self.edge_dict[tuple((roi_out, roi_in))] = float(np.absolute(
+                    cor[idx_out, idx_in]))
+
+        edge_list = [(k[0], k[1], v) for k, v in self.edge_dict.items()]
+
+        self.g.add_weighted_edges_from(edge_list)
+        pass
+
     def get_graph(self):
         """
         Returns the graph object created

--- a/ndmg/nuis/__init__.py
+++ b/ndmg/nuis/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import absolute_import
+
+from .nuis import nuis

--- a/ndmg/nuis/nuis.py
+++ b/ndmg/nuis/nuis.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python
+
+# Copyright 2016 NeuroData (http://neuromri_dat.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# nuis.py
+# Created by Eric Bridgeford on 2016-06-20-16.
+# Email: ebridge2@jhu.edu
+from ndmg.utils import utils as mgu
+import nibabel as nb
+import numpy as np
+from ndmg.stats import alignment_qc as mgqc
+import scipy.signal as signal
+from scipy import fftpack as scifft
+
+class nuis(object):
+
+    def __init__(self):
+        """
+        A class for nuisance correction of fMRI.
+        """
+        pass
+
+    def normalize_signal(self, data):
+        """
+        A function that performs normalization to a
+        given fMRI signal. We subtract out the mean of
+        each dimension, and then normalze our signal
+        by the difference between the maximum and the minimum.
+
+        **Positional Arguments:**
+            data:
+                - the fMRI data. Should be passed as an ndarray,
+                  with dimensions [ntimesteps, nvoxels].
+        """
+        # remove the voxels that are unchanging, as normalizing
+        # these by std would lead to a divide by 0
+        data = data[:, data.std(axis=0) != 0]
+        data = signal.detrend(data, axis=0, type='linear')
+        data = data - data.mean(axis=0)
+        # normalize the signal
+        data = np.divide(data, data.std(axis=0))
+        # returns the normalized signal
+        return data
+
+    def compcor(self, masked_ts, n=None, t=None):
+        """
+        A function to extract principal components on
+        timeseries of nuisance variables.
+
+        **Positional Arguments:**
+            masked_ts:
+                - the timeseries over a masked region.
+            n:
+                - the number of components to use. Default is None.
+                  Note that either n or t should be set, but not
+                  both.
+            t:
+                - the threshold for the amount of expected variance,
+                  as a float between 0 and 1, where the number of
+                  components returned will be less than the threshold
+                  indicated.
+        """
+        print "Extracting Nuisance Components..."
+        # normalize the signal to mean center
+        masked_ts = self.normalize_signal(masked_ts)
+        # singular value decomposition to get the ordered
+        # principal components
+        U, s, V = np.linalg.svd(masked_ts)
+        if n is not None and t is not None:
+            raise ValueError('CompCor: you have passed both a number of \
+                              components and a threshold. You should pass \
+                              one or the other, not both.')
+        elif n is not None:
+            # return the top n principal components
+            return U[:, 0:n], s
+        elif t is not None:
+            var_per_comp = s/np.sum(s)  # percent variance of each component
+            total_var = np.cumsum(var_per_comp)
+            thresh_var = total_var[total_var > t]
+            # return up to lowest component greater than threshold
+            idx = np.argmin(thresh_var)
+            return U[:, 0:idx], s
+        else:
+            raise ValueError('CompCor: you have not passed a threshold nor \
+                              a number of components. You must specify one.')
+        pass
+
+    def freq_filter(self, mri, tr, highpass=0.01, lowpass=None):
+        """
+        A function that uses scipy's fft and ifft to frequency filter
+        an fMRI image.
+
+        **Positional Arguments:**
+            mri:
+                - an ndarray containing timeseries of dimensions
+                  [voxels,timesteps] which the user wants to have
+                  frequency filtered.
+            highpass:
+                - the lower limit frequency band to remove below.
+            lowpass:
+                - the upper limit  frequency band to remove above.
+        """
+        # apply the fft per voxel to take to fourier domain
+        fftd = np.apply_along_axis(np.fft.fft, 0, mri)
+
+        # get the frequencies returned by the fft that we want
+        # to use. note that this function returns us a single-sided
+        # set of frequencies.
+        freq_ra = np.fft.fftfreq(mri.shape[0], d=tr)
+
+        bpra = np.zeros(freq_ra.shape, dtype=bool)
+
+        # figure out which positions we will exclude
+        if highpass is not None:
+            print "filtering below " + str(highpass) + " Hz..."
+            bpra[freq_ra < highpass] = True
+        if lowpass is not None:
+            print "filtering above " + str(lowpass) + " Hz..."
+            bpra[freq_ra > lowpass] = True
+        print "Applying Frequency Filtering..."
+        fftd[bpra, :] = 0
+        # go back to time domain
+        return np.apply_along_axis(np.fft.ifft, 0, fftd)
+
+    def regress_signal(self, data, R):
+        """
+        Regresses data to given regressors.
+
+        **Positional Arguments:**
+            - data:
+                - the data as a ndarray.
+            - R:
+                - a numpy ndarray of regressors to
+                  regress to.
+        """
+        print "Calculating Regressors..."
+        # OLS solution for GLM B = (X^TX)^(-1)X^TY
+        coefs = np.linalg.inv(R.T.dot(R)).dot(R.T).dot(data)
+        return R.dot(coefs)
+
+    def segment_anat(self, amri, an, basename):
+        """
+        A function to use FSL's FAST to segment an anatomical
+        image into GM, WM, and CSF maps.
+
+        **Positional Arguments:**
+            - amri:
+                - an anatomical image.
+            - an:
+                - an integer representing the type of the anatomical image.
+                  (1 for T1w, 2 for T2w, 3 for PD).
+            - basename:
+                - the basename for outputs. Often it will be
+                  most convenient for this to be the dataset,
+                  followed by the subject, followed by the step of
+                  processing. Note that this anticipates a path as well;
+                  ie, /path/to/dataset_sub_nuis, with no extension.
+        """
+        print "Segmenting Anatomical Image into WM, GM, and CSF..."
+        # run FAST, with options -t for the image type and -n to
+        # segment into CSF (pve_0), WM (pve_1), GM (pve_2)
+        cmd = " ".join(["fast -t", str(int(an)), "-n 3 -o", basename, amri])
+        mgu().execute_cmd(cmd)
+        pass
+
+    def erode_mask(self, mask_path, eroded_path, v=0):
+        """
+        A function to erode a mask by a specified number of
+        voxels. Here, we define erosion as the process of checking
+        whether all the voxels within a number of voxels for a
+        mask have values.
+
+        **Positional Arguments:**
+            - mask_path:
+                - a path to a nifti containing a mask.
+            - eroded_path:
+                - a path to the eroded mask to be created.
+            - v:
+                - the number of voxels to erode by.
+        """
+        print "Eroding Mask..."
+        mask_img = nb.load(mask_path)
+        mask = mask_img.get_data()
+        for i in range(0, v):
+            # masked_vox is a tuple 0f [x]. [y]. [z] cooords
+            # wherever mask is nonzero
+            erode_mask = np.zeros(mask.shape)
+            x, y, z = np.where(mask != 0)
+            if (x.shape == y.shape and y.shape == z.shape):
+                # iterated over all the nonzero voxels
+                for j in range(0, x.shape[0]):
+                    # check that the 3d voxels within 1 voxel are 1
+                    # if so, add to the new mask
+                    md = mask.shape
+                    if (mask[x[j], y[j], z[j]] and
+                            mask[np.min((x[j]+1, md[0]-1)), y[j], z[j]] and
+                            mask[x[j], np.min((y[j]+1, md[1]-1)), z[j]] and
+                            mask[x[j], y[j], np.min((z[j]+1, md[2]-1))] and
+                            mask[np.max((x[j]-1, 0)), y[j], z[j]] and
+                            mask[x[j], np.max((y[j]-1, 0)), z[j]] and
+                            mask[x[j], y[j], np.max((z[j]-1, 0))]):
+                        erode_mask[x[j], y[j], z[j]] = 1
+            else:
+                raise ValueError('Your mask erosion has an invalid shape.')
+            mask = erode_mask
+        eroded_mask_img = nb.Nifti1Image(mask,
+                                         header=mask_img.header,
+                                         affine=mask_img.get_affine())
+        nb.save(eroded_mask_img, eroded_path)
+        return mask
+
+    def extract_mask(self, prob_map, mask_path, t):
+        """
+        A function to extract a mask from a probability map.
+        Also, performs mask erosion as a substep.
+
+        **Positional Arguments:**
+            - prob_map:
+                - the path to probability map for the given class
+                  of brain tissue.
+            - mask_path:
+                - the path to the extracted mask.
+            - t:
+                - the threshold to consider voxels part of the class.
+        """
+        print "Extracting Mask from probability map..."
+        prob = nb.load(prob_map)
+        prob_dat = prob.get_data()
+        mask = (prob_dat > t).astype(int)
+        img = nb.Nifti1Image(mask,
+                             header=prob.header,
+                             affine=prob.get_affine())
+        # save the corrected image
+        nb.save(img, mask_path)
+        return mask
+
+    def linear_reg(self, voxel, csf_reg=None):
+        """ 
+        A function to perform quadratic detrending of fMRI data.
+
+        **Positional Arguments**
+            - voxel:
+                - an ndarray containing a voxel timeseries.
+                  dimensions should be [timesteps, voxels]
+            - csf_reg:
+                - a timeseries for csf mean regression. If not
+                  provided, regression will not be performed.
+        """
+        # time dimension is now the 0th dim
+        time = voxel.shape[0]
+        # linear drift regressor
+        lin_reg = np.array(range(0, time))
+        # quadratic drift regressor
+        quad_reg = np.array(range(0, time))**2
+
+        # use GLM model given regressors to approximate the weight we want
+        # to regress out
+        R = np.column_stack((np.ones(time), lin_reg, quad_reg))
+        if csf_reg is not None:
+            # add coefficients to our regression
+            np.column_stack((R, csf_reg))
+
+        W = self.regress_signal(voxel, R)
+        # corr'd ts is the difference btwn the original timeseries and
+        # our regressors, and then we transpose back
+        return (voxel - W)
+
+    def nuis_correct(self, fmri, nuisance_mri, er_csfmask=None, highpass=0.01,
+                     lowpass=None, qcdir=None):
+        """
+        Removes Nuisance Signals from brain images, using a combination
+        of Frequency filtering, and mean csf/quadratic regression.
+
+        **Positional Arguments:**
+            - fmri:
+                - the path to a fmri brain as a nifti image.
+            - nuisance_fmri:
+                - the desired path for the nuisance corrected brain.
+            - wmmask:
+                - the path to a white matter mask (should be eroded ahead of
+                  time).
+            - er_csfmask:
+                - the path to a lateral ventricles csf mask.
+            - highpass:
+                - the highpass cutoff for FFT.
+            - lowpass:
+                - the lowpass cutoff for FFT. NOT recommended.
+            - qcdir:
+                - the quality control directory to place qc.
+        """
+        fmri_name = mgu().get_filename(fmri)
+        fmri_im = nb.load(fmri)
+
+        fmri_dat = fmri_im.get_data()
+        basic_mask = fmri_dat.sum(axis=3) > 0
+        # load the voxel timeseries and transpose
+        # remove voxels that are absolutely non brain (zero activity)
+        voxel = fmri_dat[basic_mask, :].T
+
+        # zooms are x, y, z, t
+        tr = fmri_im.header.get_zooms()[3]
+
+        # highpass filter voxel timeseries appropriately
+        if er_csfmask is not None:
+            # csf regressor is the mean of all voxels in the csf
+            # mask at each time point
+            lv_im = nb.load(er_csfmask)
+            lvm = lv_im.get_data()
+            lv_ts = fmri_dat[lvm != 0, :].T
+            csf_reg = lv_ts.mean(axis=1)
+        else:
+            csf_reg = None 
+
+        nuis_voxel = self.linear_reg(voxel, csf_reg = csf_reg)
+
+        voxel = self.freq_filter(voxel, tr, highpass=highpass, lowpass=lowpass)
+        # put the nifti back together again and re-transpose
+        fmri_dat[basic_mask, :] = nuis_voxel.T
+        img = nb.Nifti1Image(fmri_dat,
+                             header=fmri_im.header,
+                             affine=fmri_im.affine)
+        # save the corrected image
+        nb.save(img, nuisance_mri)
+        pass

--- a/ndmg/nuis/nuis.py
+++ b/ndmg/nuis/nuis.py
@@ -338,7 +338,7 @@ class nuis(object):
         fmri_dat[basic_mask, :] = nuis_voxel.T
 
         # correct for T1 effect
-        fmri_dat = fmri_dat[:, 2:]
+        fmri_dat = fmri_dat[:, trim:]
         img = nb.Nifti1Image(fmri_dat,
                              header=fmri_im.header,
                              affine=fmri_im.affine)

--- a/ndmg/nuis/nuis.py
+++ b/ndmg/nuis/nuis.py
@@ -326,7 +326,9 @@ class nuis(object):
 
         lc_voxel = self.linear_reg(voxel, csf_reg = csf_reg)
 
-        nuis_voxel = self.freq_filter(lc_voxel, tr, highpass=highpass, lowpass=lowpass)
+        # nuis_voxel = self.freq_filter(lc_voxel, tr, highpass=highpass,
+        #                                lowpass=lowpass)
+        nuis_voxel = lc_voxel
         # put the nifti back together again and re-transpose
         fmri_dat[basic_mask, :] = nuis_voxel.T
         img = nb.Nifti1Image(fmri_dat,

--- a/ndmg/nuis/nuis.py
+++ b/ndmg/nuis/nuis.py
@@ -324,9 +324,9 @@ class nuis(object):
         else:
             csf_reg = None 
 
-        nuis_voxel = self.linear_reg(voxel, csf_reg = csf_reg)
+        lc_voxel = self.linear_reg(voxel, csf_reg = csf_reg)
 
-        voxel = self.freq_filter(voxel, tr, highpass=highpass, lowpass=lowpass)
+        nuis_voxel = self.freq_filter(lc_voxel, tr, highpass=highpass, lowpass=lowpass)
         # put the nifti back together again and re-transpose
         fmri_dat[basic_mask, :] = nuis_voxel.T
         img = nb.Nifti1Image(fmri_dat,

--- a/ndmg/nuis/nuis.py
+++ b/ndmg/nuis/nuis.py
@@ -337,8 +337,7 @@ class nuis(object):
         # put the nifti back together again and re-transpose
         fmri_dat[basic_mask, :] = nuis_voxel.T
 
-        # correct for T1 effect
-        fmri_dat = fmri_dat[:, trim:]
+        fmri_dat = fmri_dat[:, :, :, trim:]
         img = nb.Nifti1Image(fmri_dat,
                              header=fmri_im.header,
                              affine=fmri_im.affine)

--- a/ndmg/nuis/nuis.py
+++ b/ndmg/nuis/nuis.py
@@ -146,7 +146,7 @@ class nuis(object):
                 - a numpy ndarray of regressors to
                   regress to.
         """
-        print "Calculating Regressors..."
+        print "GLM with Design Matrix of Dimensions " + str(R.shape) + "..."
         # OLS solution for GLM B = (X^TX)^(-1)X^TY
         coefs = np.linalg.inv(R.T.dot(R)).dot(R.T).dot(data)
         return R.dot(coefs)
@@ -271,7 +271,7 @@ class nuis(object):
         R = np.column_stack((np.ones(time), lin_reg, quad_reg))
         if csf_reg is not None:
             # add coefficients to our regression
-            np.column_stack((R, csf_reg))
+            R = np.column_stack((R, csf_reg))
 
         W = self.regress_signal(voxel, R)
         # corr'd ts is the difference btwn the original timeseries and
@@ -322,12 +322,12 @@ class nuis(object):
             lv_ts = fmri_dat[lvm != 0, :].T
             csf_reg = lv_ts.mean(axis=1)
         else:
-            csf_reg = None 
+            csf_reg = None
 
         lc_voxel = self.linear_reg(voxel, csf_reg = csf_reg)
 
-        # nuis_voxel = self.freq_filter(lc_voxel, tr, highpass=highpass,
-        #                                lowpass=lowpass)
+        nuis_voxel = self.freq_filter(lc_voxel, tr, highpass=highpass,
+                                      lowpass=lowpass)
         nuis_voxel = lc_voxel
         # put the nifti back together again and re-transpose
         fmri_dat[basic_mask, :] = nuis_voxel.T

--- a/ndmg/nuis/nuis.py
+++ b/ndmg/nuis/nuis.py
@@ -279,7 +279,7 @@ class nuis(object):
         return (voxel - W)
 
     def nuis_correct(self, fmri, nuisance_mri, er_csfmask=None, highpass=0.01,
-                     lowpass=None, qcdir=None):
+                     lowpass=None, trim=0, qcdir=None):
         """
         Removes Nuisance Signals from brain images, using a combination
         of Frequency filtering, and mean csf/quadratic regression.
@@ -298,6 +298,11 @@ class nuis(object):
                 - the highpass cutoff for FFT.
             - lowpass:
                 - the lowpass cutoff for FFT. NOT recommended.
+            - trim:
+                - trim the timeseries by a number of slices. Corrects
+                  for T1 effects; that is, in some datasets, the first few
+                  timesteps may have a non-saturated T1 contrast and as such
+                  will show non-standard intensities.
             - qcdir:
                 - the quality control directory to place qc.
         """
@@ -331,6 +336,9 @@ class nuis(object):
         nuis_voxel = lc_voxel
         # put the nifti back together again and re-transpose
         fmri_dat[basic_mask, :] = nuis_voxel.T
+
+        # correct for T1 effect
+        fmri_dat = fmri_dat[:, 2:]
         img = nb.Nifti1Image(fmri_dat,
                              header=fmri_im.header,
                              affine=fmri_im.affine)

--- a/ndmg/preproc/__init__.py
+++ b/ndmg/preproc/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
 # Prevent typing multilevel imports
 from . import *
+from .preproc_fmri import preproc_fmri as preproc_fmri
 from .rescale_bvec import rescale_bvec as rescale_bvec

--- a/ndmg/preproc/preproc_fmri.py
+++ b/ndmg/preproc/preproc_fmri.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python
+
+# Copyright 2016 NeuroData (http://neurodata.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# preproc_fmri.py
+# Created by Eric Bridgeford on 2016-06-20-16.
+# Email: ebridge2@jhu.edu
+
+import numpy as np
+import nibabel as nb
+import sys
+import os.path as op
+import os.path
+import nilearn as nl
+from ndmg.utils import utils as mgu
+from scipy import signal
+from ndmg.stats import alignment_qc as mgqc
+
+
+class preproc_fmri(object):
+
+    def __init__(self):
+        """
+        Enables preprocessing of single images for single images. Has options
+        to perform motion correction.
+        """
+        pass
+
+    def motion_correct(self, mri, corrected_mri, idx):
+        """
+        Performs motion correction of a stack of 3D images.
+
+        **Positional Arguments:**
+            mri (String):
+                 -the 4d (fMRI) image volume as a nifti file.
+            corrected_mri (String):
+                - the corrected and aligned fMRI image volume.
+        """
+        cmd = "mcflirt -in " + mri + " -out " + corrected_mri +\
+            " -plots -refvol " + str(idx)
+        mgu().execute_cmd(cmd)
+        pass
+
+    def slice_time_correct(self, mri, corrected_mri, stc=None):
+        """
+        Performs slice timing correction of a stack of 3D images.
+
+        **Positional Arguments:**
+            mri (String):
+                 -the 4d (fMRI) image volume as a nifti file.
+            corrected_mri (String):
+                - the corrected and aligned fMRI image volume.
+            stc: the slice timing correction options, a string
+                  corresponding to the acquisition sequence.
+                  Options are "/path/to/file", "down", "up",
+                  "interleaved". If a file is passed, each line
+                  should correspond to a single value (in TRs)
+                  of the shift of each slice. For example,
+                  if the first slice has no shift, the first line
+                  in the text file would be "0.5".
+                  If not None, make sure the "zooms" property is set
+                  in your data (nb.load(mri).header.get_zooms()), otherwise
+                  this function will throw an error.
+        """
+        if (stc is not None):
+            if (stc != "None"):
+                cmd = "slicetimer -i " + mri + " -o " + corrected_mri
+                if stc == "down":
+                    cmd += " --down"
+                elif stc == "interleaved":
+                    cmd += " --odd"
+                elif stc == "up":
+                    # do nothing, as this is default behavior
+                    pass
+                elif op.isfile(stc):
+                    cmd += " --tcustom " + str(stc)
+                else:
+                    raise ValueError("You have not passed a valid slice-timing " +
+                                     "option")
+                zooms = nb.load(mri).header.get_zooms()
+                cmd += " -r " + str(zooms[3])
+                mgu().execute_cmd(cmd)
+            else:
+                # do nothing since we don't want to slice time correct
+                print("User Specified No slice timing correction")
+        else:
+            print "No slice timing information provided, so skipping."
+        pass
+
+    def smooth(self, mri, smoothed_mri):
+        """
+        Smooths a nifti image by applying a fwhm filter of specified diameter.
+
+        *Positional Arguments:*
+            mri: the mri to smooth.
+            smoothed_mri: the smoothed mri path.
+        """
+        pass
+
+    def preprocess(self, mri, preproc_mri, motion_mri,
+                   outdir, stc=None, qcdir="", scanid=""):
+        """
+        A function to preprocess a stack of 3D images.
+
+        **Positional Arguments:**
+
+            mri:
+                - the 4d (fMRI) image volume as a nifti file (String).
+            motion_mri:
+                - the 4d (fMRI) image volume that is motion aligned (String).
+            preproc_mri:
+                - the 4d (fMRI) preprocessed image volume
+                as a nifti image (String).
+            stc:
+                - the slice timing correction information. See documentation
+                  for slice_time_correct() for details.
+            mri_name:
+                - the name to append before all paths for file naming.
+            outdir:
+                - the location to place outputs (String).
+            qcdir:
+                - optional argument required for quality control output
+                directory (String).
+            scanid:
+                - optional argument required for quality control, is the id
+                of the subject (String).
+        """
+        mri_name = mgu().get_filename(mri)
+
+        s0 = mgu().name_tmps(outdir, mri_name, "_0slice.nii.gz")
+        stc_mri = mgu().name_tmps(outdir, mri_name, "_stc.nii.gz")
+        # TODO EB: decide whether it is advantageous to align to mean image
+        if (stc is not None):
+            self.slice_time_correct(mri, stc_mri, stc)
+        else:
+            stc_mri = mri
+        self.motion_correct(stc_mri, motion_mri, 0)
+
+        if qcdir is not None:
+            mgu().get_slice(motion_mri, 0, s0)
+            mgqc().check_alignments(mri, motion_mri, s0, qcdir, mri_name,
+                                    title="Motion Correction")
+            mgqc().image_align(motion_mri, s0, qcdir, scanid=mri_name,
+                               refid=mri_name + "_s0")
+
+        cmd = "cp " + motion_mri + " " + preproc_mri
+        mgu().execute_cmd(cmd)
+        pass

--- a/ndmg/register/register.py
+++ b/ndmg/register/register.py
@@ -25,7 +25,7 @@ import ndmg.utils.utils as mgu
 import nibabel as nb
 import numpy as np
 import nilearn.image as nl
-
+from ndmg.stats import qa_regmri as mrqc
 
 class register(object):
 

--- a/ndmg/register/register.py
+++ b/ndmg/register/register.py
@@ -21,12 +21,12 @@
 
 from subprocess import Popen, PIPE
 import os.path as op
-import ndmg.utils.utils as mgu
+from ndmg.utils import utils as mgu
 import nibabel as nb
 import numpy as np
 import nilearn.image as nl
-from ndmg.stats import qa_regmri as mrqc
-from ndmg/stats import fmri_qc as mgqc
+from ndmg.stats.qa_regmri import *
+from ndmg.stats import alignment_qc as mgqc
 
 
 class register(object):
@@ -306,6 +306,7 @@ class register(object):
         warp_mpr2temp = mgu().name_tmps(outdir, mri_name,
                                         "_warp_mpr2temp.nii.gz")
 
+        print dir(mgu)
         mgu().get_slice(mri, 0, s0)  # get the 0 slice and save
         # extract the anatomical brain
         # use threshold of .1 so that we don't accidentally cut off
@@ -335,8 +336,8 @@ class register(object):
         if qcdir is not None:
             mgqc().check_alignments(mri, aligned_mri, atlas, qcdir,
                                     mri_name, title="Registration")
-            mrqc().reg_mri_pngs(aligned_mri, atlas, qcdir, mean=True)
-            mrqc().reg_mri_pngs(aligned_anat, atlas, qcdir, dim=3)
+            reg_mri_pngs(aligned_mri, atlas, qcdir, mean=True)
+            reg_mri_pngs(aligned_anat, atlas, qcdir, dim=3)
         pass
 
     def dti2atlas(self, dti, gtab, mprage, atlas,

--- a/ndmg/register/register.py
+++ b/ndmg/register/register.py
@@ -103,8 +103,9 @@ class register(object):
                 - a mask in which voxels will be extracted
                 during nonlinear alignment.
         """
+        # run FNIRT with MNI config file
         cmd = "fnirt --in=" + inp + " --aff=" + xfm + " --cout=" +\
-              warp + " --ref=" + ref + " --subsamp=4,2,1,1"
+              warp + " --ref=" + ref + " --config=T1_2_MNI152_2mm"
         if mask is not None:
             cmd += " --refmask=" + mask
         status = mgu().execute_cmd(cmd)

--- a/ndmg/register/register.py
+++ b/ndmg/register/register.py
@@ -26,6 +26,8 @@ import nibabel as nb
 import numpy as np
 import nilearn.image as nl
 from ndmg.stats import qa_regmri as mrqc
+from ndmg/stats import fmri_qc as mgqc
+
 
 class register(object):
 

--- a/ndmg/register/register.py
+++ b/ndmg/register/register.py
@@ -39,7 +39,8 @@ class register(object):
         import ndmg.utils as mgu
         pass
 
-    def align(self, inp, ref, xfm):
+    def align(self, inp, ref, xfm=None, out=None, dof=12, searchrad=True,
+              bins=256, interp=None, cost="mutualinfo"):
         """
         Aligns two images and stores the transform between them
 
@@ -51,12 +52,60 @@ class register(object):
                     - Image being aligned to as a nifti image file
                 xfm:
                     - Returned transform between two images
+                out:
+                    - determines whether the image will be automatically
+                    aligned.
+                dof:
+                    - the number of degrees of freedom of the alignment.
+                searchrad:
+                    - a bool indicating whether to use the predefined
+                    searchradius parameter (180 degree sweep in x, y, and z).
+                interp:
+                    - the interpolation method to use. Default is trilinear.
         """
-        cmd = "flirt -in " + inp + " -ref " + ref + " -omat " + xfm +\
-              " -cost mutualinfo -bins 256 -dof 12 -searchrx -180 180" +\
-              " -searchry -180 180 -searchrz -180 180"
-        print("Executing: " + cmd)
+        cmd = "flirt -in " + inp + " -ref " + ref
+        if xfm is not None:
+            cmd += " -omat " + xfm
+        if out is not None:
+            cmd += " -out " + out
+        if dof is not None:
+            cmd += " -dof " + str(dof)
+        if bins is not None:
+            cmd += " -bins " + str(bins)
+        if interp is not None:
+            cmd += " -interp " + str(interp)
+        if cost is not None:
+            cmd += " -cost " + str(cost)
+        if searchrad is not None:
+            cmd += " -searchrx -180 180 -searchry -180 180 " +\
+                   "-searchrz -180 180"
         mgu().execute_cmd(cmd)
+        pass
+
+    def align_nonlinear(self, inp, ref, xfm, warp, mask=None):
+        """
+        Aligns two images using nonlinear methods and stores the
+        transform between them.
+
+        **Positional Arguments:**
+
+            inp:
+                - the input image.
+            ref:
+                - the reference image.
+            affxfm:
+                - the affine transform to use.
+            warp:
+                - the path to store the nonlinear warp.
+            mask:
+                - a mask in which voxels will be extracted
+                during nonlinear alignment.
+        """
+        cmd = "fnirt --in=" + inp + " --aff=" + xfm + " --cout=" +\
+              warp + " --ref=" + ref + " --subsamp=4,2,1,1"
+        if mask is not None:
+            cmd += " --refmask=" + mask
+        status = mgu().execute_cmd(cmd)
         pass
 
     def applyxfm(self, inp, ref, xfm, aligned):
@@ -77,6 +126,35 @@ class register(object):
         cmd = "".join(["flirt -in ", inp, " -ref ", ref, " -out ", aligned,
                        " -init ", xfm, " -interp trilinear -applyxfm"])
         print("Executing: " + cmd)
+        mgu().execute_cmd(cmd)
+        pass
+
+    def apply_warp(self, inp, out, ref, warp, xfm=None, mask=None):
+        """
+        Applies a warp from the functional to reference space
+        in a single step, using information about the structural->ref
+        mapping as well as the functional to structural mapping.
+
+        **Positional Arguments:**
+
+            inp:
+                - the input image to be aligned as a nifti image file.
+            out:
+                - the output aligned image.
+            ref:
+                - the image being aligned to.
+            warp:
+                - the warp from the structural to reference space.
+            premat:
+                - the affine transformation from functional to
+                structural space.
+        """
+        cmd = "applywarp --ref=" + ref + " --in=" + inp + " --out=" + out +\
+              " --warp=" + warp
+        if xfm is not None:
+            cmd += " --premat=" + xfm
+        if mask is not None:
+            cmd += " --mask=" + mask
         mgu().execute_cmd(cmd)
         pass
 
@@ -120,6 +198,143 @@ class register(object):
                                     interpolation="nearest")
         # Saves new image
         nb.save(target_im, ingested)
+        pass
+
+    def resample_ant(self, base, res, template):
+        """
+        A function to resample a base image to that of a template image
+        using dipy.
+        NOTE: Dipy is far superior for antisotropic -> isotropic
+            resampling.
+
+        **Positional Arguments:**
+
+            base:
+                - the path to the base image to resample.
+            res:
+                - the filename after resampling.
+            template:
+                - the template image to align to.
+        """
+        print("Resampling " + str(base) + " to " + str(template) + "...")
+        baseimg = nb.load(base)
+        tempimg = nb.load(template)
+        data2, affine2 = dr.reslice(baseimg.get_data(),
+                                    baseimg.get_affine(),
+                                    baseimg.get_header().get_zooms()[:3],
+                                    tempimg.get_header().get_zooms()[:3])
+        img2 = nb.Nifti1Image(data2, affine2)
+        nb.save(img2, res)
+        pass
+
+    def resample_fsl(self, base, res, template):
+        """
+        A function to resample a base image in fsl to that of a template.
+        **Positional Arguments:**
+
+           base:
+                - the path to the base image to resample.
+            res:
+                - the filename after resampling.
+            template:
+                - the template image to align to.
+        """
+        goal_res = int(nb.load(template).get_header().get_zooms()[0])
+        cmd = "flirt -in " + base + " -ref " + template + " -out " +\
+              res + " -nosearch -applyisoxfm " + str(goal_res)
+        mgu().execute_cmd(cmd)
+        pass
+
+    def combine_xfms(self, xfm1, xfm2, xfmout):
+        """
+        A function to combine two transformations, and output the
+        resulting transformation.
+
+        **Positional Arguments**
+            xfm1:
+                - the path to the first transformation
+            xfm2:
+                - the path to the second transformation
+            xfmout:
+                - the path to the output transformation
+        """
+        cmd = "convert_xfm -omat " + xfmout + " -concat " + xfm1 + " " + xfm2
+        mgu().execute_cmd(cmd)
+        pass
+
+    def fmri2atlas(self, mri, anat, atlas, atlas_brain, atlas_mask,
+                   aligned_mri, aligned_anat, outdir, qcdir=None):
+        """
+        A function to change coordinates from the subject's
+        brain space to that of a template using nonlinear
+        registration.
+
+        **Positional Arguments:**
+
+            mri:
+                - the path of the preprocessed mri image.
+            anat:
+                - the path of the raw anatomical scan.
+            atlas:
+                - the template atlas.
+            atlas_brain:
+                - the template brain.
+            atlas_mask:
+                - the template mask.
+            aligned_mri:
+                - the name of the aligned mri scan to produce.
+            aligned_anat:
+                - the name of the aligned anatomical scan to
+                produce
+            outdir:
+                - the output base directory.
+            qcdir:
+                - the quality control directory. If None, then
+                no QC will be performed.
+       """
+        mri_name = mgu().get_filename(mri)
+        anat_name = mgu().get_filename(anat)
+        atlas_name = mgu().get_filename(atlas)
+
+        s0 = mgu().name_tmps(outdir, mri_name, "_0slice.nii.gz")
+        s0_brain = mgu().name_tmps(outdir, mri_name, "_0slice_brain.nii.gz")
+        anat_brain = mgu().name_tmps(outdir, mri_name, "_anat_brain.nii.gz")
+        xfm_func2mpr = mgu().name_tmps(outdir, mri_name, "_xfm_func2mpr.mat")
+        xfm_mpr2temp = mgu().name_tmps(outdir, mri_name, "_xfm_mpr2temp.mat")
+        warp_mpr2temp = mgu().name_tmps(outdir, mri_name,
+                                        "_warp_mpr2temp.nii.gz")
+
+        mgu().get_slice(mri, 0, s0)  # get the 0 slice and save
+        # extract the anatomical brain
+        # use threshold of .1 so that we don't accidentally cut off
+        # any brain tissue while segmenting. cutting off brain tissue
+        # leads to disasterous registration failures
+        mgu().extract_brain(anat, anat_brain)
+        # extract the brain from the s0 image
+        mgu().extract_brain(s0, s0_brain)
+        # align the anatomical brain to the s0 brain
+        self.align(s0_brain, anat_brain, xfm_func2mpr, bins=None)
+        # align the anatomical high-res brain to the high-res atlas_brain
+        # this linear transformation gives us a starting point for
+        # our nonlinear transformations
+        self.align(anat_brain, atlas_brain, xfm_mpr2temp, bins=None)
+        # align the anatomical image to the atlas image using
+        # the linear alignment as a starting guess. extract over atlas_brain.
+        self.align_nonlinear(anat, atlas, xfm_mpr2temp,
+                             warp_mpr2temp, mask=atlas_mask)
+        # apply the warp obtained from anat -> atlas to the fmri stack.
+        self.apply_warp(mri, aligned_mri, atlas, warp_mpr2temp,
+                        xfm=xfm_func2mpr)
+        # apply the warp back to the anatomical image for quality control.
+        self.apply_warp(anat, aligned_anat, atlas, warp_mpr2temp,
+                        mask=atlas_mask)
+        # mgu().extract_brain(aligned_anat, aligned_anat)
+
+        if qcdir is not None:
+            mgqc().check_alignments(mri, aligned_mri, atlas, qcdir,
+                                    mri_name, title="Registration")
+            mgqc().image_align(aligned_mri, atlas_brain, qcdir,
+                               scanid=mri_name, refid=atlas_name)
         pass
 
     def dti2atlas(self, dti, gtab, mprage, atlas,

--- a/ndmg/register/register.py
+++ b/ndmg/register/register.py
@@ -306,7 +306,6 @@ class register(object):
         warp_mpr2temp = mgu().name_tmps(outdir, mri_name,
                                         "_warp_mpr2temp.nii.gz")
 
-        print dir(mgu)
         mgu().get_slice(mri, 0, s0)  # get the 0 slice and save
         # extract the anatomical brain
         # use threshold of .1 so that we don't accidentally cut off

--- a/ndmg/register/register.py
+++ b/ndmg/register/register.py
@@ -333,8 +333,8 @@ class register(object):
         if qcdir is not None:
             mgqc().check_alignments(mri, aligned_mri, atlas, qcdir,
                                     mri_name, title="Registration")
-            mgqc().image_align(aligned_mri, atlas_brain, qcdir,
-                               scanid=mri_name, refid=atlas_name)
+            mrqc().reg_mri_pngs(aligned_mri, atlas, qcdir, mean=True)
+            mrqc().reg_mri_pngs(aligned_anat, atlas, qcdir, dim=3)
         pass
 
     def dti2atlas(self, dti, gtab, mprage, atlas,

--- a/ndmg/scripts/fngs_pipeline.py
+++ b/ndmg/scripts/fngs_pipeline.py
@@ -152,6 +152,7 @@ def fngs_pipeline(fmri, struct, an, atlas, atlas_brain, atlas_mask, lv_mask,
     mgqc().stat_summary(aligned_fmri, fmri, motion_fmri, atlas_mask, voxel,
                         aligned_struct, atlas_brain,
                         qcdir=overalldir, scanid=fmri_name, qc_html=qc_html)
+
     for idx, label in enumerate(label_name):
         print "Extracting ROI timeseries for " + label + " parcellation..."
         try:

--- a/ndmg/scripts/fngs_pipeline.py
+++ b/ndmg/scripts/fngs_pipeline.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python
+
+# Copyright 2016 NeuroData (http://neurodata.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# fmri_pipeline.py
+# Created by Eric Bridgeford on 2016-06-07.
+# Email: gkiar@jhu.edu, wgr@jhu.edu, ebridge2@jhu.edu
+
+from argparse import ArgumentParser
+from datetime import datetime
+from subprocess import Popen, PIPE
+import os.path as op
+from ndmg.utils import utils as mgu
+from ndmg import register as mgr
+from ndmg import graph as mgg
+import numpy as np
+import nibabel as nb
+from ndmg.timeseries import timeseries as mgts
+from ndmg.stats import fmri_qc as mgqc
+from ndmg.preproc import preproc_fmri as mgp
+from ndmg.nuis import nuis as mgn
+from ndmg.stats import alignment_qc as mggqc
+
+
+def fngs_pipeline(fmri, struct, an, atlas, atlas_brain, atlas_mask, lv_mask,
+                  labels, outdir, clean=False, stc=None, fmt='gpickle'):
+    """
+    Analyzes fMRI images and produces subject-specific derivatives.
+
+    **Positional Arguments:**
+        fmri:
+            - the path to a 4D (fMRI) image.
+        struct:
+            - the path to a 3d (anatomical) image.
+        an:
+            - an integer indicating the type of anatomical image.
+              (1 for T1w, 2 for T2w, 3 for PD).
+        atlas:
+            - the path to a reference atlas.
+        atlas_brain:
+            - the path to a reference atlas, brain extracted.
+        atlas_mask:
+            - the path to a reference brain mask.
+        lv_mask:
+            - the path to the lateral ventricles mask.
+        labels:
+            - a list of labels files.
+        stc:
+            - a slice timing correction file. See slice_time_correct() in the
+              preprocessing module for details.
+        outdir:
+            - the base output directory to place outputs.
+        clean:
+            - a flag whether or not to clean out directories once finished.
+        fmt:
+            - the format for produced . Supported options are gpickle and
+            graphml.
+    """
+    startTime = datetime.now()
+    # Create derivative output directories
+    fmri_name = op.splitext(op.splitext(op.basename(fmri))[0])[0]
+    struct_name = op.splitext(op.splitext(op.basename(struct))[0])[0]
+    atlas_name = op.splitext(op.splitext(op.basename(atlas))[0])[0]
+
+    qcdir = outdir + "/qc"
+    mcdir = qcdir + "/mc/" + fmri_name
+    regdir = qcdir + "/reg/" + fmri_name
+    overalldir = qcdir + "/overall/" + fmri_name
+    roidir = qcdir + "/roi/" + fmri_name
+    nuisdir = qcdir + "/nuis/" + fmri_name
+
+    cmd = "mkdir -p " + outdir + "/reg_fmri " + outdir +\
+        "/preproc_fmri " + outdir + "/motion_fmri " + outdir +\
+        "/voxel_timeseries " + outdir + "/roi_timeseries " +\
+        outdir + "/reg_struct " + outdir + "/tmp " +\
+        outdir + "/connectomes " + outdir + "/nuis_fmri " + qcdir + " " +\
+        mcdir + " " + regdir + " " + overalldir + " " + roidir + " " + nuisdir
+    mgu().execute_cmd(cmd)
+
+    qc_html = overalldir + "/" + fmri_name + ".html"
+
+    mggqc().generate_html_templated(qc_html)
+
+    # Graphs are different because of multiple atlases
+    if isinstance(labels, list):
+        label_name = [op.splitext(op.splitext(op.basename(x))[0])[0]
+                      for x in labels]
+        for label in label_name:
+            p = Popen("mkdir -p " + outdir + "/roi_timeseries/" + label,
+                      stdout=PIPE, stderr=PIPE, shell=True)
+            p = Popen("mkdir -p " + outdir + "/connectomes/" + label,
+                      stdout=PIPE, stderr=PIPE, shell=True)
+            p = Popen("mkdir -p " + roidir + "/" + label,
+                      stdout=PIPE, stderr=PIPE, shell=True)
+    else:
+        label_name = op.splitext(op.splitext(op.basename(labels))[0])[0]
+        p = Popen("mkdir -p " + outdir + "/roi_timeseries/" + label_name,
+                  stdout=PIPE, stderr=PIPE, shell=True)
+        p = Popen("mkdir -p " + outdir + "/connectomes/" + label_name,
+                  stdout=PIPE, stderr=PIPE, shell=True)
+        p = Popen("mkdir -p " + roidir + "/" + label_name,
+                  stdout=PIPE, stderr=PIPE, shell=True)
+
+    # Create derivative output file names
+    preproc_fmri = outdir + "/preproc_fmri/" + fmri_name + "_preproc.nii.gz"
+    aligned_fmri = outdir + "/reg_fmri/" + fmri_name + "_aligned.nii.gz"
+    aligned_struct = outdir + "/reg_struct/" + fmri_name +\
+        "_anat_aligned.nii.gz"
+    motion_fmri = outdir + "/motion_fmri/" + fmri_name + "_mc.nii.gz"
+    nuis_fmri = outdir + "/nuis_fmri/" + fmri_name + "_nuis.nii.gz"
+    voxel_ts = outdir + "/voxel_timeseries/" + fmri_name + "_voxel.npz"
+
+    print "This pipeline will produce the following derivatives..."
+    print "fMRI volumes preprocessed: " + preproc_fmri
+    print "fMRI volumes motion corrected: " + motion_fmri
+    print "fMRI volume registered to atlas: " + aligned_fmri
+    print "Voxel timecourse in atlas space: " + voxel_ts
+    print "Quality Control HTML Page: " + qc_html
+    # Again, connectomes are different
+    connectomes = [outdir + "/connectomes/" + x + '/' + fmri_name +
+                   "_" + x + '.' + fmt for x in label_name]
+    roi_ts = [outdir + "/roi_timeseries/" + x + '/' + fmri_name + "_" + x +
+              ".npz" for x in label_name]
+    print "ROI timecourse downsampled to given labels: " +\
+          (", ".join([x for x in roi_ts]))
+
+    # Align fMRI volumes to Atlas
+    print "Preprocessing volumes..."
+    mgp().preprocess(fmri, preproc_fmri, motion_fmri, outdir,
+                     qcdir=mcdir, stc=stc)
+    print "Aligning volumes..."
+    mgr().fmri2atlas(preproc_fmri, struct, atlas, atlas_brain, atlas_mask,
+                     aligned_fmri, aligned_struct, outdir,
+                     qcdir=regdir)
+    print "Correcting Nuisance Variables..."
+    mgn().nuis_correct(aligned_fmri, nuis_fmri, lv_mask, qcdir=nuisdir)
+    print "Extracting Voxelwise Timeseries..."
+    voxel = mgts().voxel_timeseries(nuis_fmri, atlas_mask, voxel_ts)
+    mgqc().stat_summary(aligned_fmri, fmri, motion_fmri, atlas_mask, voxel,
+                        aligned_struct, atlas_brain,
+                        qcdir=overalldir, scanid=fmri_name, qc_html=qc_html)
+    for idx, label in enumerate(label_name):
+        print "Extracting ROI timeseries for " + label + " parcellation..."
+        try:
+            ts = mgts().roi_timeseries(nuis_fmri, labels[idx], roi_ts[idx],
+                                       qcdir=roidir + "/" + label,
+                                       scanid=fmri_name, refid=label)
+            mggqc().image_align(atlas_brain, labels[idx], roidir + "/" + label,
+                                scanid=atlas_name, refid=label)
+        except OSError as err:
+            print(err)
+        connectome = mgg(ts.shape[0], labels[idx], sens="Functional")
+        connectome.cor_graph(ts)
+        connectome.summary()
+        connectome.save_graph(connectomes[idx], fmt=fmt)
+
+    if clean:
+        cmd = "rm -r " + outdir + "/tmp/" + fmri_name + "*"
+        mgu().execute_cmd(cmd)
+
+    print "Complete! FNGS first run"
+    pass
+
+
+def main():
+    parser = ArgumentParser(description="This is an end-to-end connectome \
+                            estimation pipeline from sMRI and DTI images")
+    parser.add_argument("fmri", action="store", help="Nifti fMRI stack")
+    parser.add_argument("struct", action="store", help="Nifti aMRI")
+    parser.add_argument("an", action="store", help="anatomical image type. \
+                        1 for T1w (default), 2 for T2w, 3 for PD.", default=1)
+    parser.add_argument("atlas", action="store", help="Nifti T1 MRI atlas")
+    parser.add_argument("atlas_brain", action="store", help="Nifti T1 MRI \
+                        brain only atlas")
+    parser.add_argument("atlas_mask", action="store", help="Nifti binary mask \
+                        of brain space in the atlas")
+    parser.add_argument("lv_mask", action="store", help="Nifti binary mask of \
+                        lateral ventricles in atlas space.")
+    parser.add_argument("outdir", action="store", help="Path to which \
+                        derivatives will be stored")
+    parser.add_argument("labels", action="store", nargs="*", help="Nifti \
+                        labels of regions of interest in atlas space")
+    parser.add_argument("-c", "--clean", action="store_true", default=False,
+                        help="Whether or not to delete intemediates")
+    parser.add_argument("-s", "--stc", action="store", help="A file for slice \
+                        timing correction. Options are a TR sequence file \
+                        (where \ each line is the shift in TRs), \
+                        up (ie, bottom to top), down (ie, top to bottom), \
+                        and interleaved.", default=None)
+    parser.add_argument("-f", "--fmt", action="store", default='gpickle',
+                        help="Determines connectome output format")
+    result = parser.parse_args()
+
+    # Create output directory
+    cmd = "mkdir -p " + result.outdir + " " + result.outdir + "/tmp"
+    print "Creating output directory: " + result.outdir
+    print "Creating output temp directory: " + result.outdir + "/tmp"
+    mgu().execute_cmd(cmd)
+
+    fngs_pipeline(result.fmri, result.struct, int(result.an), result.atlas,
+                  result.atlas_brain, result.atlas_mask, result.lv_mask,
+                  result.labels, result.outdir, result.clean, result.stc,
+                  result.fmt)
+
+
+if __name__ == "__main__":
+    main()

--- a/ndmg/scripts/fngs_pipeline.py
+++ b/ndmg/scripts/fngs_pipeline.py
@@ -90,9 +90,9 @@ def fngs_pipeline(fmri, struct, an, atlas, atlas_brain, atlas_mask, lv_mask,
         mcdir + " " + regdir + " " + overalldir + " " + roidir + " " + nuisdir
     mgu().execute_cmd(cmd)
 
-    qc_html = overalldir + "/" + fmri_name + ".html"
+    # qc_html = overalldir + "/" + fmri_name + ".html"
 
-    mggqc().generate_html_templated(qc_html)
+    # mggqc().generate_html_templated(qc_html)
 
     # Graphs are different because of multiple atlases
     if isinstance(labels, list):
@@ -128,7 +128,7 @@ def fngs_pipeline(fmri, struct, an, atlas, atlas_brain, atlas_mask, lv_mask,
     print "fMRI volumes motion corrected: " + motion_fmri
     print "fMRI volume registered to atlas: " + aligned_fmri
     print "Voxel timecourse in atlas space: " + voxel_ts
-    print "Quality Control HTML Page: " + qc_html
+    # print "Quality Control HTML Page: " + qc_html
     # Again, connectomes are different
     connectomes = [outdir + "/connectomes/" + x + '/' + fmri_name +
                    "_" + x + '.' + fmt for x in label_name]
@@ -151,7 +151,7 @@ def fngs_pipeline(fmri, struct, an, atlas, atlas_brain, atlas_mask, lv_mask,
     voxel = mgts().voxel_timeseries(nuis_fmri, atlas_mask, voxel_ts)
     mgqc().stat_summary(aligned_fmri, fmri, motion_fmri, atlas_mask, voxel,
                         aligned_struct, atlas_brain,
-                        qcdir=overalldir, scanid=fmri_name, qc_html=qc_html)
+                        qcdir=overalldir, scanid=fmri_name)
 
     for idx, label in enumerate(label_name):
         print "Extracting ROI timeseries for " + label + " parcellation..."

--- a/ndmg/scripts/fngs_pipeline.py
+++ b/ndmg/scripts/fngs_pipeline.py
@@ -146,7 +146,7 @@ def fngs_pipeline(fmri, struct, an, atlas, atlas_brain, atlas_mask, lv_mask,
                      aligned_fmri, aligned_struct, outdir,
                      qcdir=regdir)
     print "Correcting Nuisance Variables..."
-    mgn().nuis_correct(aligned_fmri, nuis_fmri, lv_mask, qcdir=nuisdir)
+    mgn().nuis_correct(aligned_fmri, nuis_fmri, lv_mask, trim=2, qcdir=nuisdir)
     print "Extracting Voxelwise Timeseries..."
     voxel = mgts().voxel_timeseries(nuis_fmri, atlas_mask, voxel_ts)
     mgqc().stat_summary(aligned_fmri, fmri, motion_fmri, atlas_mask, voxel,

--- a/ndmg/scripts/ndmg_demo-func
+++ b/ndmg/scripts/ndmg_demo-func
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+echo "Getting test data..."
+
+loc="$PWD"
+cd /tmp/
+wget http://openconnecto.me/mrdata/share/demo_data/ndmg_demo.zip
+unzip -o /tmp/ndmg_demo.zip
+wget http://openconnecto.me/mrdata/share/atlases/fmri_atlases.zip
+unzip -o /tmp/fmri_atlases.zip
+res=4mm
+
+fngs_pipeline /tmp/ndmg_demo/sub-0025864_session-1_bold_small.nii.gz /tmp/ndmg_demo/sub-0025864_session-1_T1w_small.nii.gz 1 /tmp/atlases/atlas/MNI152_T1-${res}.nii.gz /tmp/atlases/atlas/MNI152_T1-${res}_brain.nii.gz /tmp/atlases/mask/MNI152_T1-${res}_brain_mask.nii.gz /tmp/atlases/mask/HarvOx_lv_thr25-${res}.nii.gz /tmp/ndmg_test/outputs /tmp/atlases/label/desikan-${res}.nii.gz -s interleaved
+
+#ndmg_pipeline /tmp/ndmg_demo/sub-0025864_session-1_dwi.nii.gz /tmp/ndmg_demo/sub-0025864_session-1_dwi.bval /tmp/ndmg_demo/sub-0025864_session-1_dwi.bvec /tmp/ndmg_demo/sub-0025864_session-1_T1w_small.nii.gz /tmp/atlases/atlas/MNI152_T1_${res}.nii.gz /tmp/atlases/mask/MNI152_T1_${res}_brain_mask.nii.gz /tmp/ndmg_test/outputs /tmp/atlases/label/desikan-${res}.nii.gz
+
+
+cd "$loc"

--- a/ndmg/scripts/ndmg_pipeline.py
+++ b/ndmg/scripts/ndmg_pipeline.py
@@ -24,7 +24,7 @@ from __future__ import print_function
 from argparse import ArgumentParser
 from datetime import datetime
 from subprocess import Popen, PIPE
-from ndmg.stats.qa_regdti import *
+from ndmg.stats.qa_regmri import *
 from ndmg.stats.qa_tensor import *
 from ndmg.stats.qa_fibers import *
 import ndmg.utils as mgu

--- a/ndmg/scripts/ndmg_pipeline.py
+++ b/ndmg/scripts/ndmg_pipeline.py
@@ -89,7 +89,7 @@ def ndmg_pipeline(dti, bvals, bvecs, mprage, atlas, mask, labels, outdir,
     print("Aligning volumes...")
     mgr().dti2atlas(dti1, gtab, mprage, atlas, aligned_dti, outdir, clean)
     b0loc = np.where(gtab.b0s_mask)[0][0]
-    reg_dti_pngs(aligned_dti, b0loc, atlas, outdir+"/qa/reg_dti/")
+    reg_mri_pngs(aligned_dti, atlas, outdir+"/qa/reg_dti/", loc=b0loc)
 
     print("Beginning tractography...")
     # Compute tensors and track fiber streamlines

--- a/ndmg/stats/__init__.py
+++ b/ndmg/stats/__init__.py
@@ -3,4 +3,3 @@ from __future__ import absolute_import
 from . import *
 from .fmri_qc import fmri_qc
 from .alignment_qc import alignment_qc
-

--- a/ndmg/stats/__init__.py
+++ b/ndmg/stats/__init__.py
@@ -1,3 +1,6 @@
 from __future__ import absolute_import
 # Prevent typing multilevel imports
 from . import *
+from .fmri_qc import fmri_qc
+from .alignment_qc import alignment_qc
+

--- a/ndmg/stats/alignment_qc.py
+++ b/ndmg/stats/alignment_qc.py
@@ -254,7 +254,7 @@ class alignment_qc(object):
         """
         cmap = basemap(reference)
         # all values beteween 0 opacity and .6
-        denom = float(np.nanmax(reference))
+        denom = np.nanmax(reference).astype(float)
         denom[denom == 0] = 1  # so we don't get divide by zero
         opaque_scale = alpha*reference/denom
         # remaps intensities

--- a/ndmg/stats/alignment_qc.py
+++ b/ndmg/stats/alignment_qc.py
@@ -254,7 +254,9 @@ class alignment_qc(object):
         """
         cmap = basemap(reference)
         # all values beteween 0 opacity and .6
-        opaque_scale = alpha*reference/float(np.nanmax(reference))
+        denom = float(np.nanmax(reference)
+        denom[denom == 0] = 1  # so we don't get divide by zero
+        opaque_scale = alpha*reference/denom
         # remaps intensities
         cmap[:, :, 3] = opaque_scale
         return cmap

--- a/ndmg/stats/alignment_qc.py
+++ b/ndmg/stats/alignment_qc.py
@@ -1,0 +1,494 @@
+# Copyright 2016 NeuroData (http://neurodata.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# qc.py
+# Created by Eric W Bridgeford on 2016-06-08.
+# Email: ebridge2@jhu.edu
+
+from numpy import ndarray as nar
+import numpy as np
+from scipy.stats import gaussian_kde
+from subprocess import Popen, PIPE
+import nibabel as nb
+import sys
+import re
+import random as ran
+import scipy.stats.mstats as scim
+import os.path
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+from ndmg.utils import utils as mgu
+import plotly as py
+import plotly.offline as offline
+
+
+class alignment_qc(object):
+    def __init__(self):
+        """
+        Enables quality control of fMRI and DTI processing pipelines.
+        """
+        pass
+
+    def dice_coefficient(self, a, b):
+        """
+        dice coefficient 2nt/na + nb.
+        Code taken from https://en.wikibooks.org/wiki/Algorithm_Implementation
+        /Strings/Dice%27s_coefficient#Python
+
+        ** Positional Arguments:**
+            a:
+                - the first array.
+            b:
+                - the second array.
+        """
+        a = nar.tolist(nar.flatten(a))
+        b = nar.tolist(nar.flatten(b))
+        if not len(a) or not len(b):
+            return 0.0
+        if len(a) == 1:
+            a = a + u'.'
+        if len(b) == 1:
+            b = b + u'.'
+
+        a_bigram_list = []
+        for i in range(len(a)-1):
+            a_bigram_list.append(a[i:i+2])
+        b_bigram_list = []
+        for i in range(len(b)-1):
+            b_bigram_list.append(b[i:i+2])
+
+        a_bigrams = set(a_bigram_list)
+        b_bigrams = set(b_bigram_list)
+        overlap = len(a_bigrams & b_bigrams)
+        dice_coeff = overlap * 2.0/float(len(a_bigrams) + len(b_bigrams))
+        return dice_coeff
+
+    def mse(self, imageA, imageB):
+        """
+        the 'Mean Squared Error' between the two images is the
+        sum of the squared difference between the two images;
+        NOTE: the two images must have the same dimension
+        from http://www.pyimagesearch.com/2014/09/15/python-compare-two-images/
+        NOTE: we've normalized the signals by the mean intensity at each
+        point to make comparisons btwn fMRI and MPRAGE more viable.
+        Otherwise, fMRI signal vastly overpowers MPRAGE signal and our MSE
+        would have very low accuracy (fMRI signal differences >>> actual
+        differences we are looking for).
+
+        **Positional Arguments:**
+            imageA:
+                - the first image.
+            imageB:
+                - the second image.
+        """
+        err = np.sum((imageA.astype("float") - imageB.astype("float")) ** 2)
+        err /= (float(imageA.shape[0] * imageA.shape[1]))
+
+        return float(err)
+
+    def compute_kdes(self, before, after, steps=1000):
+        """
+        A function to plot kdes of the arrays for the similarity between
+        the before/reference and after/reference.
+
+        **Positional Arguments:**
+            before:
+                - a numpy array before an operational step.
+            after:
+                - a numpy array after an operational step.
+        """
+        x_min = min(np.nanmin(before), np.nanmin(after))
+        x_max = max(np.nanmax(before), np.nanmax(after))
+        x_grid = np.linspace(x_min, x_max, steps)
+        kdebef = gaussian_kde(before)
+        kdeaft = gaussian_kde(after)
+        return [x_grid, kdebef.evaluate(x_grid), kdeaft.evaluate(x_grid)]
+
+    def hdist(self, array1, array2):
+        """
+        A function for computing the hellinger distance between arrays
+        1 and 2.
+
+        **Positional Arguments:**
+            array1:
+                - the first array.
+            array2:
+                - the second array.
+        """
+        return np.sqrt(np.sum((np.sqrt(array1) -
+                              np.sqrt(array2)) ** 2)) / float(np.sqrt(2))
+
+    def check_alignments(self, mri_bname, mri_aname, refname, qcdir,
+                         fname, title=""):
+        """
+        A function to check alignments and generate descriptive statistics
+        and plots based on the overlap between two images.
+
+        **Positional Arguments**
+            mri_bname:
+                - the 4d mri file before an operation has taken place
+            mri_aname:
+                - the 4d mri file after an operation has taken place
+            refname:
+                - the 3d file used as a reference for the operation
+            qcdir:
+                - the output directory for the plots
+            title:
+                - a string (such as the operation name) for use in the plot
+                     titles (defaults to "")
+            fname:
+                - a string to use in the file handle for easy finding
+        """
+        print "Performing Quality Control for " + title + "..."
+        print "\tBefore " + title + ": " + mri_bname
+        print "\tAfter " + title + ": " + mri_aname
+        print "\tReference " + title + ": " + refname
+
+        # load the nifti images
+        mri_before = nb.load(mri_bname)
+        mri_after = nb.load(mri_aname)
+        reference = nb.load(refname)
+
+        # resample if not in same image space
+        if not all(x in mri_after.header.get_zooms()[:3] for x in
+                   mri_before.header.get_zooms()[:3]) or not all(x
+                   in mri_after.header.get_data_shape()[:3] for x in
+                   mri_before.header.get_data_shape()[:3]):
+
+            mri_tname = qcdir + "/" + fname + "_res.nii.gz"
+            from ndmg import register as mgr
+            mgr().resample_fsl(mri_bname, mri_tname, refname)
+            mri_before = nb.load(mri_tname)
+
+        # load the data contained for each image
+        mri_bdata = mri_before.get_data()
+        mri_adata = mri_after.get_data()
+        refdata = reference.get_data()
+
+        nvols = mri_bdata.shape[3]
+        nslices = mri_bdata.shape[2]
+
+        v_bef = []
+        v_aft = []
+
+        refdata = np.divide(refdata, np.mean(refdata) + 1)
+        for t in range(0, nvols):
+            mribefdat = np.divide(mri_bdata[:, :, :, t],
+                                  np.mean(mri_bdata[:, :, :, t]) + 1)
+            mriaftdat = np.divide(mri_adata[:, :, :, t],
+                                  np.mean(mri_adata[:, :, :, t]) + 1)
+            for s in range(0, nslices):
+                v_bef.append(tuple((s + ran.random(),
+                                    self.mse(mribefdat[:, :, s],
+                                             refdata[:, :, s]))))
+                v_aft.append(tuple((s + ran.random(),
+                                    self.mse(mriaftdat[:, :, s],
+                                             refdata[:, :, s]))))
+
+        kdes = self.compute_kdes(zip(*v_bef)[1], zip(*v_aft)[1])
+
+        xlim = tuple((0, np.nanmax(kdes[0])))
+        ylim = tuple((0, max(np.nanmax(kdes[1]), np.nanmax(kdes[2]))))
+        axkde_list = []
+        axkde_list.append(py.graph_objs.Scatter(x=kdes[0], y=kdes[1],
+                          fillcolor='(0, 0, 255, 1)', mode='lines',
+                          name='before mean = %.2E' % np.mean(zip(*v_bef)[1])))
+        axkde_list.append(py.graph_objs.Scatter(x=kdes[0], y=kdes[2],
+                          fillcolor='(255, 0, 0, 1)', mode='lines',
+                          name='after mean = %.2E' % np.mean(zip(*v_aft)[1])))
+        layout = dict(title=title +
+                      (" Hellinger Distance = %.4E" %
+                       self.hdist(zip(*v_bef)[1], zip(*v_aft)[1])),
+                      xaxis=dict(title='MSE', range=xlim),
+                      yaxis=dict(title='Density', range=ylim))
+        fkde = dict(data=axkde_list, layout=layout)
+        path = qcdir + "/" + fname + "_kde.html"
+        offline.plot(fkde, filename=path, auto_open=False)
+
+        xlim = tuple((0, nslices + 1))
+        ylim = tuple((0, max(np.nanmax(zip(*v_bef)[1]),
+                             np.nanmax(zip(*v_aft)[1]))))
+        axjit_list = []
+        axjit_list.append(py.graph_objs.Scatter(x=zip(*v_bef)[0],
+                          y=zip(*v_bef)[1],
+                          name='before mean = %.2E' % np.mean(zip(*v_bef)[1]),
+                          marker=dict(size=3.0, color='rgba(0, 0, 255, 1)'),
+                          mode='markers'))
+        axjit_list.append(py.graph_objs.Scatter(x=zip(*v_aft)[0],
+                          y=zip(*v_aft)[1],
+                          name='after mean = %.2E' % np.mean(zip(*v_aft)[1]),
+                          marker=dict(size=3.0, color='rgba(255, 0, 0, 1)'),
+                          mode='markers'))
+        layout = dict(title="Jitter Plot showing slicewise impact of " +
+                      title,
+                      xaxis=dict(title='Slice Number', range=xlim),
+                      yaxis=dict(title='MSE', range=ylim))
+        fjit = dict(data=axjit_list, layout=layout)
+        path = qcdir + "/" + fname + "_jitter.html"
+        offline.plot(fjit, filename=path, auto_open=False)
+        pass
+
+    def opaque_colorscale(self, basemap, reference, alpha=0.5):
+        """
+        A function to return a colorscale, with opacities
+        dependent on reference intensities.
+
+        **Positional Arguments:**
+            - basemap:
+                - the colormap to use for this colorscale.
+            - reference:
+                - the reference matrix.
+        """
+        cmap = basemap(reference)
+        # all values beteween 0 opacity and .6
+        opaque_scale = alpha*reference/float(np.nanmax(reference))
+        # remaps intensities
+        cmap[:, :, 3] = opaque_scale
+        return cmap
+
+    def expected_variance(self, s, n, qcdir, scanid="", title=""):
+        """
+        A function to show the expected variance of each component
+        in nuisance regression.
+
+        **Positional Arguments:**
+            - s:
+                - an array of the variance of each component, or the
+                  eigenvalues computed in SVD/eigendecomposition for each
+                  component (should be sorted by variance).
+            - n:
+                - the number of components chosen for compcor.
+            - qcdir:
+                - the directory to place outputs in.
+            - scanid:
+                - the id of the particular subject.
+            - title:
+                - the method being employed that an expected variance
+                  plot is neede for. Examples are "CompCor" or "PCA".
+        """
+        # normalize so that it sums to one
+        s = s/np.sum(s)
+        total_var = np.cumsum(s)
+        # the variance accounted for by the top used components
+        var_acct = total_var[n-1]
+
+        colors = ['rgba(255,0, 0,1)'] * s.shape[0]
+        colors[n] = 'rgba(26,200,255,1)'
+        axvar = [py.graph_objs.Bar(x=range(s.shape[0]), y=s,
+                 marker=dict(color=colors))]
+        layout = dict(title=" ".join([title, "Scree Plot,", "N=", str(n),
+                                      ",", "Var=", str(var_acct)]),
+                      xaxis=dict(title='Component'),
+                      yaxis=dict(title='Variance'))
+        fvar = dict(data=axvar, layout=layout)
+        offline.plot(fvar, filename=str(qcdir + "/" + scanid + "_scree.html"),
+                     auto_open=False)
+
+    def mask_align(self, mri_data, ref_data, qcdir, scanid="", refid=""):
+        """
+        A function to produce an image showing the alignments of two
+        reference images for checking mask alignments.
+
+        **Positional Arguments:**
+            mri_image:
+                - the first matrix.
+            ref_image:
+                - the reference matrix.
+            qcdir:
+                - the path to a directory to dump the outputs.
+            scan_id:
+                - the id of the scan being analyzed.
+            refid:
+                - the id of the reference being analyzed.
+        """
+        cmd = "mkdir -p " + qcdir
+        mgu().execute_cmd(cmd)
+        mri_data = mgu().get_braindata(mri_data)
+        ref_data = mgu().get_braindata(ref_data)
+
+        # if we have 4d data, np.mean() to get 3d data
+        if len(mri_data.shape) == 4:
+            mri_data = np.nanmean(mri_data, axis=3)
+
+        falign = plt.figure()
+
+        depth = mri_data.shape[2]
+
+        depth_seq = np.unique(np.round(np.linspace(0, depth-1, 25)))
+        nrows = np.ceil(np.sqrt(depth_seq.shape[0]))
+        ncols = np.ceil(depth_seq.shape[0]/float(nrows))
+
+        # produce figures for each slice in the image
+        for d in range(0, depth_seq.shape[0]):
+            # TODO EB: create nifti image with these values
+            # and allow option to add overlap with mni vs mprage
+            i = depth_seq[d]
+            axalign = falign.add_subplot(nrows, ncols, d+1)
+            axalign.imshow(self.opaque_colorscale(matplotlib.cm.Blues,
+                                                  mri_data[:, :, i], 0.6))
+            axalign.imshow(self.opaque_colorscale(matplotlib.cm.Reds,
+                                                  ref_data[:, :, i], 0.4))
+            axalign.set_xlabel('Position (res)')
+            axalign.set_ylabel('Position (res)')
+            axalign.set_title('%d slice' % i)
+        falign.set_size_inches(nrows*6, ncols*6)
+        falign.tight_layout()
+        fname = qcdir + "/" + scanid + "_" + refid + "_overlap.png"
+        falign.savefig(fname)
+        plt.close(falign)
+        # return the figpath so we can save it back to the html
+        return fname
+
+    def image_align(self, mri_data, ref_data, qcdir, scanid="", refid=""):
+        """
+        A function to produce an image showing the alignments of two
+        reference images.
+
+        **Positional Arguments:**
+            mri_image:
+                - the first matrix.
+            ref_image:
+                - the reference matrix.
+            qcdir:
+                - the path to a directory to dump the outputs.
+            scan_id:
+                - the id of the scan being analyzed.
+            refid:
+                - the id of the reference being analyzed.
+        """
+        cmd = "mkdir -p " + qcdir
+        mgu().execute_cmd(cmd)
+        mri_data = mgu().get_braindata(mri_data)
+        ref_data = mgu().get_braindata(ref_data)
+
+        # if we have 4d data, np.mean() to get 3d data
+        if len(mri_data.shape) == 4:
+            mri_data = np.nanmean(mri_data, axis=3)
+
+        falign = plt.figure()
+
+        depth = mri_data.shape[2]
+
+        depth_seq = np.unique(np.round(np.linspace(0, depth - 1, 25)))
+        nrows = np.ceil(np.sqrt(depth_seq.shape[0]))
+        ncols = np.ceil(depth_seq.shape[0]/float(nrows))
+
+        # produce figures for each slice in the image
+        for d in range(0, depth_seq.shape[0]):
+            # TODO EB: create nifti image with these values
+            # and allow option to add overlap with mni vs mprage
+            i = depth_seq[d]
+            axalign = falign.add_subplot(nrows, ncols, d+1)
+            axalign.imshow(self.opaque_colorscale(matplotlib.cm.Blues,
+                                                  mri_data[:, :, i]))
+            axalign.imshow(self.opaque_colorscale(matplotlib.cm.Reds,
+                                                  ref_data[:, :, i]))
+            axalign.set_xlabel('Position (res)')
+            axalign.set_ylabel('Position (res)')
+            axalign.set_title('%d slice' % i)
+        falign.set_size_inches(nrows*6, ncols*6)
+        falign.tight_layout()
+        fname = qcdir + "/" + scanid + "_" + refid + "_overlap.png"
+        falign.savefig(fname)
+        plt.close(falign)
+        # return the figpath so we can save it back to the html
+        return fname
+
+    def plot_timeseries(self, timeseries, qcdir=None,
+                        scanid=None, refid=None):
+        """
+        A function to generate a plot of the timeseries
+        of the particular ROI. Makes sure nothing nonsensical is
+        happening here.
+
+        **Positional Arguments:**
+            - timeseries:
+                - the timeseries.
+            - qcdir:
+                - the directory to place quality control figures.
+            - scanid:
+                - the scan id of the subject.
+            - refid:
+                - the reference of the atlas we are plotting timeseries
+                  for.
+        """
+        path = qcdir + "/" + scanid + "_" + refid
+        fname_ts = path + "_timeseries.html"
+        fname_corr = path + "_corr.png"
+
+        fts_list = []
+        for d in range(0, timeseries.T.shape[1]):
+            fts_list.append(py.graph_objs.Scatter(
+                            x=range(0, timeseries.T.shape[0]),
+                            y=timeseries.T[:, d], mode='lines'))
+        layout = dict(title=" ".join([scanid, refid, "ROI Timeseries"]),
+                      xaxis=dict(title='Time Point (TRs)',
+                                 range=[0, timeseries.T.shape[0]]),
+                      yaxis=dict(title='Intensity'),
+                      showlegend=False)  # height=405, width=720)
+        fts = dict(data=fts_list, layout=layout)
+        # py.plotly.image.save_as(fts, filename=fname_ts)
+        offline.plot(fts, filename=fname_ts, auto_open=False)
+
+        fcorr = plt.figure()
+        axcorr = fcorr.add_subplot(111)
+
+        cax = axcorr.imshow(np.corrcoef(timeseries), interpolation='nearest',
+                            cmap=plt.cm.ocean)
+        fcorr.colorbar(cax, fraction=0.046, pad=0.04)
+        axcorr.set_title(" ".join([scanid, refid, "Corr"]))
+        axcorr.set_xlabel('ROI')
+        axcorr.set_ylabel('ROI')
+
+        fcorr.set_size_inches(6, 6)
+        fcorr.tight_layout()
+        fcorr.savefig(fname_corr)
+        plt.close(fcorr)
+        pass
+
+    def generate_html_templated(self, location):
+        """
+        A function for putting the template for html in the correct
+        spot.
+
+        **Positional Arguments:**
+            - location:
+                - the spot you want the html to go.
+        """
+        cmd = "cp " + os.path.dirname(os.path.realpath(__file__)) +\
+            "/templates/qc.html " + location
+
+        mgu().execute_cmd(cmd)
+        pass
+
+    def update_template_qc(self, html_qc, dict_keys):
+        """
+        A function to update an html, using Django-style templated args.
+
+        **Positional Arguments:**
+            - html_qc:
+                - the path to the html figure to replace kwargs for.
+            - dict_keys:
+                - a dictionary containing the keys to replace and
+                  the values to replace them with.
+        """
+        template = open(html_qc).read()
+        for key, fname in dict_keys.items():
+            template = re.sub("{{ " + key + " }}", fname, template)
+        qc_html = open(html_qc, "w")
+        qc_html.write(template)
+        qc_html.close()
+        pass

--- a/ndmg/stats/alignment_qc.py
+++ b/ndmg/stats/alignment_qc.py
@@ -254,9 +254,10 @@ class alignment_qc(object):
         """
         cmap = basemap(reference)
         # all values beteween 0 opacity and .6
-        denom = np.nanmax(reference).astype(float)
-        denom[denom == 0] = 1  # so we don't get divide by zero
-        opaque_scale = alpha*reference/denom
+        denom = np.nanmax(reference)
+        if denom == 0:  # avoid divide by zero
+             denom = 1
+        opaque_scale = alpha*reference/float(denom)
         # remaps intensities
         cmap[:, :, 3] = opaque_scale
         return cmap

--- a/ndmg/stats/alignment_qc.py
+++ b/ndmg/stats/alignment_qc.py
@@ -386,7 +386,6 @@ class alignment_qc(object):
         nrows = np.ceil(np.sqrt(depth_seq.shape[0]))
         ncols = np.ceil(depth_seq.shape[0]/float(nrows))
 
-        print mri_data.shape
         # produce figures for each slice in the image
         for d in range(0, depth_seq.shape[0]):
             # TODO EB: create nifti image with these values

--- a/ndmg/stats/alignment_qc.py
+++ b/ndmg/stats/alignment_qc.py
@@ -382,10 +382,11 @@ class alignment_qc(object):
 
         depth = mri_data.shape[2]
 
-        depth_seq = np.unique(np.round(np.linspace(0, depth - 1, 25)))
+        depth_seq = np.unique(np.round(np.linspace(0, depth - 1, 25))).astype(int)
         nrows = np.ceil(np.sqrt(depth_seq.shape[0]))
         ncols = np.ceil(depth_seq.shape[0]/float(nrows))
 
+        print mri_data.shape
         # produce figures for each slice in the image
         for d in range(0, depth_seq.shape[0]):
             # TODO EB: create nifti image with these values

--- a/ndmg/stats/alignment_qc.py
+++ b/ndmg/stats/alignment_qc.py
@@ -456,7 +456,7 @@ class alignment_qc(object):
         axcorr.set_xlabel('ROI')
         axcorr.set_ylabel('ROI')
 
-        fcorr.set_size_inches(6, 6)
+        fcorr.set_size_inches(10, 10)
         fcorr.tight_layout()
         fcorr.savefig(fname_corr)
         plt.close(fcorr)

--- a/ndmg/stats/alignment_qc.py
+++ b/ndmg/stats/alignment_qc.py
@@ -254,7 +254,7 @@ class alignment_qc(object):
         """
         cmap = basemap(reference)
         # all values beteween 0 opacity and .6
-        denom = float(np.nanmax(reference)
+        denom = float(np.nanmax(reference))
         denom[denom == 0] = 1  # so we don't get divide by zero
         opaque_scale = alpha*reference/denom
         # remaps intensities

--- a/ndmg/stats/fmri_qc.py
+++ b/ndmg/stats/fmri_qc.py
@@ -133,7 +133,7 @@ class fmri_qc(object):
 
         # max image size is 5x5. after that, reduce size to 5x5
         # with sequences
-        depth_seq = np.unique(np.round(np.linspace(0, depth - 1, 25)))
+        depth_seq = np.unique(np.round(np.linspace(0, depth - 1, 25))).astype(int)
         nrows = np.ceil(np.sqrt(depth_seq.shape[0]))
         ncols = np.ceil(depth_seq.shape[0]/float(nrows))
 

--- a/ndmg/stats/fmri_qc.py
+++ b/ndmg/stats/fmri_qc.py
@@ -116,6 +116,7 @@ class fmri_qc(object):
         fmean_anat = plt.figure()
 
         mri_datstd = np.nanstd(mri_dat, axis=3)
+        mri_datstd[mri_datstd == 0] = 1  # so we don't get zeros
         fstd = plt.figure()
 
         # image for slice SNR = mean / stdev
@@ -325,9 +326,12 @@ class fmri_qc(object):
         fstat.write("Signal Mean: %.4f\n" % np.mean(voxel))
         fstat.write("Signal Stdev: %.4f\n" % np.std(voxel))
         fstat.write("Number of Voxels: %d\n" % voxel.shape[0])
+
+        voxel_std = np.std(voxel, axis=1)
+        voxel_std[voxel_std == 0] = 1  # so we dont' divide by zero
         fstat.write("Average SNR per voxel: %.4f\n" %
                     np.nanmean(np.divide(np.mean(voxel, axis=1),
-                               np.std(voxel, axis=1))))
+                               voxel_std)))
         fstat.write("\n\n")
 
         # Motion Statistics

--- a/ndmg/stats/fmri_qc.py
+++ b/ndmg/stats/fmri_qc.py
@@ -328,7 +328,8 @@ class fmri_qc(object):
         fstat.write("Number of Voxels: %d\n" % voxel.shape[0])
 
         voxel_std = np.std(voxel, axis=1)
-        voxel_std[voxel_std == 0] = 1  # so we dont' divide by zero
+        # to avoid divide by zero
+        voxel_std[voxel_std == float(0)] = float(1)
         fstat.write("Average SNR per voxel: %.4f\n" %
                     np.nanmean(np.divide(np.mean(voxel, axis=1),
                                voxel_std)))

--- a/ndmg/stats/fmri_qc.py
+++ b/ndmg/stats/fmri_qc.py
@@ -46,7 +46,7 @@ class fmri_qc(object):
 
     def stat_summary(self, mri, mri_raw, mri_mc, mask, voxel,
                      aligned_mprage, atlas, title=None, qcdir=None,
-                     scanid=None, qc_html=None):
+                     scanid=None):
         """
         A function for producing a stat summary page, along with
         an image of all the slices of this mri scan.
@@ -310,7 +310,7 @@ class fmri_qc(object):
         fnames['intens'] = scanid + "_intens.html"
         fnames['voxel_hist'] = scanid + "_voxel_hist.html"
 
-        mgqc().update_template_qc(qc_html, fnames)
+        # mgqc().update_template_qc(qc_html, fnames)
 
         fstat = open(qcdir + "/" + scanid + "_stat_sum.txt", 'w')
         fstat.write("General Information\n")

--- a/ndmg/stats/fmri_qc.py
+++ b/ndmg/stats/fmri_qc.py
@@ -1,0 +1,396 @@
+# Copyright 2016 NeuroData (http://neurodata.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# fmri_qc.py
+# Created by Eric W Bridgeford on 2016-06-08.
+# Email: ebridge2@jhu.edu
+
+from numpy import ndarray as nar
+import numpy as np
+from scipy.stats import gaussian_kde
+from subprocess import Popen, PIPE
+import nibabel as nb
+import sys
+import re
+import random as ran
+import scipy.stats.mstats as scim
+import os.path
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+from ndmg.utils import utils as mgu
+from ndmg.stats.alignment_qc import alignment_qc as mgqc
+import plotly as py
+import plotly.offline as offline
+
+
+class fmri_qc(object):
+
+    def __init__(self):
+        """
+        Enables quality control of fMRI and DTI processing pipelines.
+        """
+        pass
+
+    def stat_summary(self, mri, mri_raw, mri_mc, mask, voxel,
+                     aligned_mprage, atlas, title=None, qcdir=None,
+                     scanid=None, qc_html=None):
+        """
+        A function for producing a stat summary page, along with
+        an image of all the slices of this mri scan.
+
+        **Outputs:**
+            Mean figure:
+                - plot for each voxel's mean signal intensity for
+              each voxel in the corrected mri's timecourse
+            STdev figure:
+                - plot of the standard deviation of each voxel's
+              corrected timecourse
+            SNR figure:
+                - plot of signal to noise ratio for each voxel in the
+              corrected timecourse
+            Slice Wise Intensity figure:
+                - averages intensity over slices
+                    and plots each slice as a line for corrected mri
+                - goal: slice mean signal intensity is approximately same
+                  throughout all nvols (lines are relatively flat)
+            motion parameters figures (3):
+                - 1 figure for rotational, 1 figure for translational motion
+                  params, 1 for displacement, calculated with fsl's mcflirt
+            stat summary file:
+                - provides some useful statistics for analyzing fMRI data;
+                  see resources for each individual statistic for the
+                  computation
+
+        **Positional Arguments:**
+            - mri:
+                - the path to a corrected mri scan to analyze
+            - mri_raw:
+                - the path to an uncorrected mri scan to analyze
+            - mri_mc:
+                - the motion corrected mri scan.
+            - mask:
+                - the mask to calculate statistics over.
+            - voxel:
+                - a matrix for the voxel timeseries.
+            - aligned_mprage:
+                - the aligned MPRAGE image.
+            - atlas:
+                - the atlas for alignment.
+            - title:
+                - the title for the plots (ie, Registered, Resampled, etc)
+            - fname:
+                - the name to give the file.
+        """
+        print "Producing Quality Control Summary. \n" +\
+            "\tRaw Image: " + mri_raw + "\n" +\
+            "\tCorrected Image: " + mri + "\n" +\
+            " \tMask: " + mask + "\n"
+        cmd = "mkdir -p " + qcdir
+        mgu().execute_cmd(cmd)
+
+        mri_im = nb.load(mri)
+        mri_dat = mri_im.get_data()
+        mri_raw_im = nb.load(mri_raw)
+
+        mprage_dat = nb.load(aligned_mprage).get_data()
+        at_dat = nb.load(atlas).get_data()
+
+        print "Opened MRI Images."
+
+        # image for mean signal intensity over time
+        mri_datmean = np.nanmean(mri_dat, axis=3)
+        fmean_ref = plt.figure()
+        fmean_anat = plt.figure()
+
+        mri_datstd = np.nanstd(mri_dat, axis=3)
+        fstd = plt.figure()
+
+        # image for slice SNR = mean / stdev
+        mri_datsnr = np.divide(mri_datmean, mri_datstd)
+        mri_datsnr[np.isnan(mri_datsnr)] = 0
+        fsnr = plt.figure()
+
+        # image for slice-wise mean intensity
+        mri_datmi = np.squeeze(np.apply_over_axes(np.nanmean,
+                                                  mri_dat, (0, 1)))
+        fanat_ref = plt.figure()
+
+        depth = mri_dat.shape[2]
+        nvols = mri_dat.shape[3]
+
+        # max image size is 5x5. after that, reduce size to 5x5
+        # with sequences
+        depth_seq = np.unique(np.round(np.linspace(0, depth - 1, 25)))
+        nrows = np.ceil(np.sqrt(depth_seq.shape[0]))
+        ncols = np.ceil(depth_seq.shape[0]/float(nrows))
+
+        mri_dat = None  # done with this, so save memory here
+
+        # produce figures for each slice in the image
+        for d in range(0, depth_seq.shape[0]):
+            # TODO EB: create nifti image with these values
+            # and allow option to add overlap with ref vs mprage
+            i = depth_seq[d]
+            axmean_ref = fmean_ref.add_subplot(nrows, ncols, d+1)
+            axmean_ref.imshow(mgqc().opaque_colorscale(matplotlib.cm.Blues,
+                                                       mri_datmean[:, :, i]))
+            axmean_ref.imshow(mgqc().opaque_colorscale(matplotlib.cm.Reds,
+                                                       at_dat[:, :, i]))
+            axmean_ref.set_xlabel('Position (res)')
+            axmean_ref.set_ylabel('Position (res)')
+            axmean_ref.set_title('%d slice' % i)
+
+            axmean_anat = fmean_anat.add_subplot(nrows, ncols, d+1)
+            axmean_anat.imshow(mgqc().opaque_colorscale(matplotlib.cm.Blues,
+                                                        mri_datmean[:, :, i]))
+            axmean_anat.imshow(mgqc().opaque_colorscale(matplotlib.cm.Reds,
+                                                        mprage_dat[:, :, i]))
+            axmean_anat.set_xlabel('Position (res)')
+            axmean_anat.set_ylabel('Position (res)')
+            axmean_anat.set_title('%d slice' % i)
+
+            axstd = fstd.add_subplot(nrows, ncols, d+1)
+            axstd.imshow(mri_datstd[:, :, i], cmap='gray',
+                         interpolation='nearest', vmin=0,
+                         vmax=np.max(mri_datstd))
+            axstd.set_xlabel('Position (res)')
+            axstd.set_ylabel('Position (res)')
+            axstd.set_title('%d slice' % i)
+
+            axsnr = fsnr.add_subplot(nrows, ncols, d+1)
+            axsnr.imshow(mri_datsnr[:, :, i], cmap='gray',
+                         interpolation='nearest', vmin=0,
+                         vmax=np.max(mri_datsnr))
+            axsnr.set_xlabel('Position (res)')
+            axsnr.set_ylabel('Position (res)')
+            axsnr.set_title('%d slice' % i)
+
+            axanat_ref = fanat_ref.add_subplot(nrows, ncols, d+1)
+            axanat_ref.imshow(mgqc().opaque_colorscale(matplotlib.cm.Blues,
+                                                       mprage_dat[:, :, i]))
+            axanat_ref.set_xlabel('Position (res)')
+            axanat_ref.set_ylabel('Position (res)')
+            axanat_ref.set_title('%d slice' % i)
+            axanat_ref.imshow(mgqc().opaque_colorscale(matplotlib.cm.Reds,
+                                                       at_dat[:, :, i]))
+
+        axmi_list = []
+        for d in range(0, depth):
+            axmi_list.append(py.graph_objs.Scatter(x=range(0, nvols),
+                                                   y=mri_datmi[d, :],
+                                                   mode='lines',
+                                                   showlegend=False))
+        layout = dict(title='Mean Slice Intensity',
+                      xaxis=dict(title='Timepoint', range=[0, nvols]),
+                      yaxis=dict(title='Mean Intensity'),
+                      height=405, width=720)
+        axmi = dict(data=axmi_list, layout=layout)
+        appended_path = scanid + "_intens.html"
+        path = qcdir + "/" + appended_path
+        offline.plot(axmi, filename=path, auto_open=False)
+
+        nonzero_data = mri_datmean[mri_datmean != 0]
+        hist, bins = np.histogram(nonzero_data, bins=500,
+                                  range=(0, np.nanmean(nonzero_data) +
+                                         2*np.nanstd(nonzero_data)))
+        width = 0.7 * (bins[1] - bins[0])
+        center = (bins[:-1] + bins[1:]) / float(2)
+
+        axvih = [py.graph_objs.Bar(x=center, y=hist)]
+        layout = dict(xaxis=dict(title='Voxel Intensity'),
+                      yaxis=dict(title='Number of Voxels'),
+                      height=405, width=720)
+        fhist = dict(data=axvih, layout=layout)
+        appended_path = scanid + "_voxel_hist.html"
+        path = qcdir + "/" + appended_path
+        offline.plot(fhist, filename=path, auto_open=False)
+
+        par_file = mri_mc + ".par"
+
+        abs_pos = np.zeros((nvols, 6))
+        rel_pos = np.zeros((nvols, 6))
+        with open(par_file) as f:
+            counter = 0
+            for line in f:
+                abs_pos[counter, :] = [float(i) for i in re.split("\\s+",
+                                                                  line)[0:6]]
+                if counter > 0:
+                    rel_pos[counter, :] = np.subtract(abs_pos[counter, :],
+                                                      abs_pos[counter-1, :])
+                counter += 1
+
+        ftrans_list = []
+        ftrans_list.append(py.graph_objs.Scatter(x=range(0, nvols),
+                                                 y=abs_pos[:, 3],
+                                                 mode='lines', name='x'))
+        ftrans_list.append(py.graph_objs.Scatter(x=range(0, nvols),
+                                                 y=abs_pos[:, 4],
+                                                 mode='lines', name='y'))
+        ftrans_list.append(py.graph_objs.Scatter(x=range(0, nvols),
+                                                 y=abs_pos[:, 5],
+                                                 mode='lines', name='z'))
+        layout = dict(title='Translational Motion Parameters',
+                      xaxis=dict(title='Timepoint', range=[0, nvols]),
+                      yaxis=dict(title='Translation (mm)'))
+        ftrans = dict(data=ftrans_list, layout=layout)
+        appended_path = scanid + "_trans.html"
+        path = qcdir + "/" + appended_path
+        offline.plot(ftrans, filename=path, auto_open=False)
+
+        frot_list = []
+        frot_list.append(py.graph_objs.Scatter(x=range(0, nvols),
+                                               y=abs_pos[:, 0],
+                                               mode='lines', name='x'))
+        frot_list.append(py.graph_objs.Scatter(x=range(0, nvols),
+                                               y=abs_pos[:, 1],
+                                               mode='lines', name='y'))
+        frot_list.append(py.graph_objs.Scatter(x=range(0, nvols),
+                                               y=abs_pos[:, 2],
+                                               mode='lines', name='z'))
+        layout = dict(title='Rotational Motion Parameters',
+                      xaxis=dict(title='Timepoint', range=[0, nvols]),
+                      yaxis=dict(title='Rotation (rad)'))
+        frot = dict(data=frot_list, layout=layout)
+        appended_path = scanid + "_rot.html"
+        path = qcdir + "/" + appended_path
+        offline.plot(frot, filename=path, auto_open=False)
+
+        trans_abs = np.linalg.norm(abs_pos[:, 3:6], axis=1)
+        trans_rel = np.linalg.norm(rel_pos[:, 3:6], axis=1)
+        rot_abs = np.linalg.norm(abs_pos[:, 0:3], axis=1)
+        rot_rel = np.linalg.norm(rel_pos[:, 0:3], axis=1)
+
+        fmc_list = []
+        fmc_list.append(py.graph_objs.Scatter(x=range(0, nvols), y=trans_abs,
+                                              mode='lines', name='absolute'))
+        fmc_list.append(py.graph_objs.Scatter(x=range(0, nvols), y=trans_rel,
+                                              mode='lines', name='relative'))
+        layout = dict(title='Estimated Displacement',
+                      xaxis=dict(title='Timepoint', range=[0, nvols]),
+                      yaxis=dict(title='Movement (mm)'))
+        fmc = dict(data=fmc_list, layout=layout)
+        appended_path = scanid + "_disp.html"
+        path = qcdir + "/" + appended_path
+        offline.plot(fmc, filename=path, auto_open=False)
+
+        figures = {"mean_ref": [fmean_ref, nrows, ncols],
+                   "mean_anat": [fmean_anat, nrows, ncols],
+                   "anat_ref": [fanat_ref, nrows, ncols],
+                   "std": [fstd, nrows, ncols],
+                   "snr": [fsnr, nrows, ncols]}
+        fnames = {}
+
+        for idx, figlist in figures.items():
+            fig = figlist[0]
+            fig.set_size_inches(figlist[1]*6, figlist[2]*6)
+            fig.tight_layout()
+            appended_path = scanid + "_" + str(idx) + ".png"
+            fnames[idx] = appended_path
+            path = qcdir + "/" + appended_path
+            fig.savefig(path)
+            plt.close(fig)
+
+        fnames['sub'] = scanid
+        fnames['trans'] = scanid + "_trans.html"
+        fnames['rot'] = scanid + "_rot.html"
+        fnames['disp'] = scanid + "_disp.html"
+        fnames['intens'] = scanid + "_intens.html"
+        fnames['voxel_hist'] = scanid + "_voxel_hist.html"
+
+        mgqc().update_template_qc(qc_html, fnames)
+
+        fstat = open(qcdir + "/" + scanid + "_stat_sum.txt", 'w')
+        fstat.write("General Information\n")
+        fstat.write("Raw Image Resolution: " +
+                    str(mri_raw_im.get_header().get_zooms()[0:3]) + "\n")
+        fstat.write("Corrected Image Resolution: " +
+                    str(mri_im.get_header().get_zooms()[0:3]) + "\n")
+        fstat.write("Number of Volumes: %d" % nvols)
+
+        fstat.write("\n\n")
+        fstat.write("Signal  Statistics\n")
+        fstat.write("Signal Mean: %.4f\n" % np.mean(voxel))
+        fstat.write("Signal Stdev: %.4f\n" % np.std(voxel))
+        fstat.write("Number of Voxels: %d\n" % voxel.shape[0])
+        fstat.write("Average SNR per voxel: %.4f\n" %
+                    np.nanmean(np.divide(np.mean(voxel, axis=1),
+                               np.std(voxel, axis=1))))
+        fstat.write("\n\n")
+
+        # Motion Statistics
+        mean_abs = np.mean(abs_pos, axis=0)  # column wise means per param
+        std_abs = np.std(abs_pos, axis=0)
+        max_abs = np.max(np.abs(abs_pos), axis=0)
+        mean_rel = np.mean(rel_pos, axis=0)
+        std_rel = np.std(rel_pos, axis=0)
+        max_rel = np.max(np.abs(rel_pos), axis=0)
+        fstat.write("Motion Statistics\n")
+
+        absrel = ["absolute", "relative"]
+        transrot = ["motion", "rotation"]
+        list1 = [max(trans_abs), np.mean(trans_abs), np.sum(trans_abs > 1),
+                 np.sum(trans_abs > 5), mean_abs[3], std_abs[3], max_abs[3],
+                 mean_abs[4], std_abs[4], max_abs[4], mean_abs[5],
+                 std_abs[5], max_abs[5]]
+        list2 = [max(trans_rel), np.mean(trans_rel), np.sum(trans_rel > 1),
+                 np.sum(trans_rel > 5), mean_abs[3], std_rel[3], max_rel[3],
+                 mean_abs[4], std_rel[4], max_rel[4], mean_abs[5],
+                 std_rel[5], max_rel[5]]
+        list3 = [max(rot_abs), np.mean(rot_abs), 0, 0, mean_abs[0],
+                 std_abs[0], max_abs[0], mean_abs[1], std_abs[1],
+                 max_abs[1], mean_abs[2], std_abs[2], max_abs[2]]
+        list4 = [max(rot_rel), np.mean(rot_rel), 0, 0, mean_rel[0],
+                 std_rel[0], max_rel[0], mean_rel[1], std_rel[1],
+                 max_rel[1], mean_rel[2], std_rel[2], max_rel[2]]
+        lists = [list1, list2, list3, list4]
+        headinglist = ["Absolute Translational Statistics>>\n",
+                       "Relative Translational Statistics>>\n",
+                       "Absolute Rotational Statistics>>\n",
+                       "Relative Rotational Statistics>>\n"]
+        x = 0
+        for motiontype in transrot:
+            for measurement in absrel:
+                fstat.write(headinglist[x])
+                fstat.write("Max " + measurement + " " + motiontype +
+                            ": %.4f\n" % lists[x][0])
+                fstat.write("Mean " + measurement + " " + motiontype +
+                            ": %.4f\n" % lists[x][1])
+                if motiontype == "motion":
+                    fstat.write("Number of " + measurement + " " + motiontype +
+                                "s > 1mm: %.4f\n" % lists[x][2])
+                    fstat.write("Number of " + measurement + " " + motiontype +
+                                "s > 5mm: %.4f\n" % lists[x][3])
+                fstat.write("Mean " + measurement + " x " + motiontype +
+                            ": %.4f\n" % lists[x][4])
+                fstat.write("Std " + measurement + " x " + motiontype +
+                            ": %.4f\n" % lists[x][5])
+                fstat.write("Max " + measurement + " x " + motiontype +
+                            ": %.4f\n" % lists[x][6])
+                fstat.write("Mean " + measurement + " y " + motiontype +
+                            ": %.4f\n" % lists[x][7])
+                fstat.write("Std " + measurement + " y " + motiontype +
+                            ": %.4f\n" % lists[x][8])
+                fstat.write("Max " + measurement + " y " + motiontype +
+                            ": %.4f\n" % lists[x][9])
+                fstat.write("Mean " + measurement + " z " + motiontype +
+                            ": %.4f\n" % lists[x][10])
+                fstat.write("Std " + measurement + " z " + motiontype +
+                            ": %.4f\n" % lists[x][11])
+                fstat.write("Max " + measurement + " z " + motiontype +
+                            ": %.4f\n" % lists[x][12])
+                x = x + 1
+
+        fstat.close()

--- a/ndmg/stats/qa_regmri.py
+++ b/ndmg/stats/qa_regmri.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-# qa_regdti.py
+# qa_regmri.py
 # Created by Vikram Chandrashekhar.
 # Edited by Greg Kiar.
 # Email: Greg Kiar @ gkiar@jhu.edu
@@ -35,15 +35,15 @@ mpl.use('Agg')  # very important above pyplot import
 import matplotlib.pyplot as plt
 
 
-def reg_dti_pngs(dti, loc, atlas, outdir):
+def reg_mri_pngs(mri, loc, atlas, outdir):
     """
     outdir: directory where output png file is saved
     fname: name of output file WITHOUT FULL PATH. Path provided in outdir.
     """
 
     atlas_data = nb.load(atlas).get_data()
-    dti_data = nb.load(dti).get_data()
-    b0_data = dti_data[:,:,:,loc]
+    mri_data = nb.load(mri).get_data()
+    b0_data = mri_data[:,:,:,loc]
 
     cmap1 = LinearSegmentedColormap.from_list('mycmap1', ['black', 'magenta'])
     cmap2 = LinearSegmentedColormap.from_list('mycmap2', ['black', 'green'])
@@ -51,7 +51,7 @@ def reg_dti_pngs(dti, loc, atlas, outdir):
     fig = plot_overlays(atlas_data, b0_data, (cmap1, cmap2))
 
     # name and save the file
-    fname = os.path.split(dti)[1].split(".")[0] + '.png'
+    fname = os.path.split(mri)[1].split(".")[0] + '.png'
     plt.savefig(outdir + '/' + fname, format='png')
 
 
@@ -109,7 +109,7 @@ def plot_overlays(atlas, b0, cmaps):
 
 def get_min_max(data):
     '''
-    data: regdti data to threshold.
+    data: regmri data to threshold.
     '''
     min_val = np.percentile(data, 2)
     max_val = np.percentile(data, 95)

--- a/ndmg/stats/qa_regmri.py
+++ b/ndmg/stats/qa_regmri.py
@@ -35,7 +35,7 @@ mpl.use('Agg')  # very important above pyplot import
 import matplotlib.pyplot as plt
 
 
-def reg_mri_pngs(mri, atlas, outdir, loc=0, mean=False):
+def reg_mri_pngs(mri, atlas, outdir, loc=0, mean=False, dim=4):
     """
     outdir: directory where output png file is saved
     fname: name of output file WITHOUT FULL PATH. Path provided in outdir.
@@ -43,10 +43,13 @@ def reg_mri_pngs(mri, atlas, outdir, loc=0, mean=False):
 
     atlas_data = nb.load(atlas).get_data()
     mri_data = nb.load(mri).get_data()
-    if mean:
-        b0_data = mri_data.mean(axis=3)
-    else:
-        b0_data = mri_data[:,:,:,loc]
+    if dim=4:  # 4d data
+        if mean:
+            b0_data = mri_data.mean(axis=3)
+        else:
+            b0_data = mri_data[:,:,:,loc]
+    else:  # dim=3
+        b0_data = mri_data
 
     cmap1 = LinearSegmentedColormap.from_list('mycmap1', ['black', 'magenta'])
     cmap2 = LinearSegmentedColormap.from_list('mycmap2', ['black', 'green'])

--- a/ndmg/stats/qa_regmri.py
+++ b/ndmg/stats/qa_regmri.py
@@ -35,7 +35,7 @@ mpl.use('Agg')  # very important above pyplot import
 import matplotlib.pyplot as plt
 
 
-def reg_mri_pngs(mri, loc, atlas, outdir):
+def reg_mri_pngs(mri, atlas, outdir, loc=0, mean=False):
     """
     outdir: directory where output png file is saved
     fname: name of output file WITHOUT FULL PATH. Path provided in outdir.
@@ -43,7 +43,10 @@ def reg_mri_pngs(mri, loc, atlas, outdir):
 
     atlas_data = nb.load(atlas).get_data()
     mri_data = nb.load(mri).get_data()
-    b0_data = mri_data[:,:,:,loc]
+    if mean:
+        b0_data = mri_data.mean(axis=3)
+    else:
+        b0_data = mri_data[:,:,:,loc]
 
     cmap1 = LinearSegmentedColormap.from_list('mycmap1', ['black', 'magenta'])
     cmap2 = LinearSegmentedColormap.from_list('mycmap2', ['black', 'green'])

--- a/ndmg/stats/qa_regmri.py
+++ b/ndmg/stats/qa_regmri.py
@@ -43,7 +43,7 @@ def reg_mri_pngs(mri, atlas, outdir, loc=0, mean=False, dim=4):
 
     atlas_data = nb.load(atlas).get_data()
     mri_data = nb.load(mri).get_data()
-    if dim=4:  # 4d data
+    if dim==4:  # 4d data, so we need to reduce a dimension
         if mean:
             b0_data = mri_data.mean(axis=3)
         else:

--- a/ndmg/timeseries/__init__.py
+++ b/ndmg/timeseries/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import absolute_import
+# Prevent typing multilevel imports
+from .timeseries import timeseries

--- a/ndmg/timeseries/timeseries.py
+++ b/ndmg/timeseries/timeseries.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+
+# Copyright 2016 NeuroData (http://neurodata.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# timeseries.py
+# Created by Eric W Bridgeford on 2016-06-07.
+# Email: ericwb95@gmail.com
+
+import numpy as np
+import nibabel as nb
+import sys
+from ndmg.utils import utils as mgu
+from ndmg.stats import alignment_qc as mgqc
+
+
+class timeseries(object):
+
+    def __init__(self):
+        """
+        Timeseries extraction class
+        """
+        pass
+
+    def voxel_timeseries(self, fmri_file, mask_file, voxel_file=None):
+        """
+        Function to extract timeseries for the voxels in the provided
+        mask.
+        Returns the voxel timeseries as a numpy.ndarray.
+
+        **Positional Arguments**
+            fmri_file:
+                - the path to the fmri 4d volume to extract timeseries.
+                can be string, nifti1image, or ndarray
+            mask_file:
+                - the path to the binary mask the user wants to extract
+                voxel timeseries over. Can be string, nifti1image, or
+                ndarray
+            voxel_file:
+                - the path to the voxel timeseries to be created.
+                Must be string. If None, don't save and just return
+                the voxel timeseries.
+        """
+        print "Extracting Voxel Timeseries for " + str(fmri_file) + "..."
+
+        # load the mask data
+        maskdata = mgu().get_braindata(mask_file)
+        maskbool = (maskdata > 0)  # extract timeseries for any labelled voxels
+
+        # load the MRI data
+        fmridata = mgu().get_braindata(fmri_file)
+        voxel_ts = fmridata[maskbool, :]
+        if voxel_file is not None:
+            np.savez(voxel_file, voxel_ts)
+        return voxel_ts
+
+    def roi_timeseries(self, fmri_file, label_file, roits_file=None,
+                       qcdir=None, scanid=None, refid=None):
+        """
+        Function to extract average timeseries for the voxels in each
+        roi of the labelled atlas.
+        Returns the roi timeseries as a numpy.ndarray.
+
+        **Positional Arguments**
+
+            fmri_file:
+                - the path to the 4d volume to extract timeseries
+            label_file:
+                - the path to the labelled atlas containing labels
+                    for the voxels in the fmri image
+            roits_file:
+                - the path to where the roi timeseries will be saved. If
+                None, don't save and just return the roi_timeseries.
+        """
+        labeldata = mgu().get_braindata(label_file)
+
+        rois = np.sort(np.unique(labeldata[labeldata > 0]))
+
+        fmridata = mgu().get_braindata(fmri_file)
+
+        # initialize so resulting ra is [numrois]x[numtimepoints]
+        roi_ts = np.zeros((rois.shape[0], fmridata.shape[3]))
+
+        for roi in rois:
+            roi_idx = np.where(rois == roi)[0][0]  # the index of the roi
+
+            roibool = (labeldata == roi)  # get a bool where our voxels in roi
+            roi_vts = fmridata[roibool, :]
+
+            # take the mean for the voxel timeseries, and ignore voxels of 0
+            # when possible.
+            ts = np.mean(roi_vts[:, roi_vts.std(axis=0) != 0], axis=0)
+            if (ts.shape == 0):
+                roi_ts[roi_idx, :] = np.mean(roi_vts, axis=0)
+            else:
+                roi_ts[roi_idx, :] = ts
+
+        if qcdir is not None:
+            mgqc().image_align(fmridata, labeldata, qcdir=qcdir,
+                               scanid=scanid, refid=refid)
+            mgqc().plot_timeseries(roi_ts, qcdir=qcdir,
+                                   scanid=scanid, refid=refid)
+
+        if roits_file:
+            np.savez(roits_file, roi_ts)
+        return roi_ts

--- a/ndmg/utils/utils.py
+++ b/ndmg/utils/utils.py
@@ -168,7 +168,7 @@ class utils():
             braindata = brain.get_data()
         return braindata
 
-    def extract_brain(self, inp, out, opts=""):
+    def extract_brain(self, inp, out, opts="-B"):
         """
         A function to extract the brain from an image using FSL's BET.
 

--- a/ndmg/utils/utils.py
+++ b/ndmg/utils/utils.py
@@ -116,6 +116,33 @@ class utils():
         """
         return op.splitext(op.splitext(op.basename(label))[0])[0]
 
+    def get_slice(self, mri, volid, sli):
+        """
+        Takes a volume index and constructs a new nifti image from
+        the specified volume.
+        **Positional Arguments:**
+            mri:
+                - the path to a 4d mri volume to extract a slice from.
+            volid:
+                - the index of the volume desired.
+            sli:
+                - the path to the destination for the slice.
+        """
+        mri_im = nb.load(mri)
+        data = mri_im.get_data()
+        # get the slice at the desired volume
+        vol = np.squeeze(data[:, :, :, volid])
+
+        # Wraps volume in new nifti image
+        head = mri_im.get_header()
+        head.set_data_shape(head.get_data_shape()[0:3])
+        out = nb.Nifti1Image(vol, affine=mri_im.get_affine(),
+                             header=head)
+        out.update_header()
+        # and saved to a new file
+        nb.save(out, sli)
+        pass
+
     def get_braindata(self, brain_file):
         """
         Opens a brain data series for a mask, mri image, or atlas.

--- a/ndmg/utils/utils.py
+++ b/ndmg/utils/utils.py
@@ -38,6 +38,22 @@ class utils():
 
         pass
 
+    def apply_mask(self, inp, masked, mask):
+        """
+        A function to apply a mask to a brain.
+
+        **Positional Arguments:**
+            inp:
+                - the input path to an mri image.
+            masked:
+                - the output path to the masked image.
+            mask:
+                - the path to a brain mask.
+        """
+        cmd = "fslmaths " + inp + " -mas " + mask + " " + masked
+        self.execute_cmd(cmd)
+        pass
+
     def load_bval_bvec_dti(self, fbval, fbvec, dti_file, dti_file_out):
         """
         Takes bval and bvec files and produces a structure in dipy format
@@ -99,6 +115,47 @@ class utils():
         Given a fully qualified path gets just the file name, without extension
         """
         return op.splitext(op.splitext(op.basename(label))[0])[0]
+
+    def get_braindata(self, brain_file):
+        """
+        Opens a brain data series for a mask, mri image, or atlas.
+        Returns a numpy.ndarray representation of a brain.
+
+        **Positional Arguements**
+            brain_file:
+                - an object to open the data for a brain.
+                Can be a string (path to a brain file),
+                nibabel.nifti1.nifti1image, or a numpy.ndarray
+        """
+        if type(brain_file) is np.ndarray:  # if brain passed as matrix
+            braindata = brain_file
+        else:
+            if type(brain_file) is str or type(brain_file) is unicode:
+                brain = nb.load(str(brain_file))
+            elif type(brain_file) is nb.nifti1.Nifti1Image:
+                brain = brain_file
+            else:
+                raise TypeError("Brain file is type " + str(type(brain_file)) +
+                                "; accepted types are numpy.ndarray, " +
+                                "string, and nibabel.nifti1.Nifti1Image.")
+            braindata = brain.get_data()
+        return braindata
+
+    def extract_brain(self, inp, out, opts=""):
+        """
+        A function to extract the brain from an image using FSL's BET.
+
+        **Positional Arguments:**
+            inp:
+                - the input image.
+            out:
+                - the output brain extracted image.
+        """
+        cmd = "bet " + inp + " " + out
+        if opts is not None:
+            cmd = cmd + " " + str(opts)
+        self.execute_cmd(cmd)
+        pass
 
     def execute_cmd(self, cmd):
         """

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,6 @@ setup(
         'dipy>=0.1',
         'boto3',
         'matplotlib==1.5.1',
-        'plotly',
+        'plotly==1.12',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -14,14 +14,18 @@ setup(
         'ndmg.graph',
         'ndmg.stats',
         'ndmg.utils',
+        'ndmg.timeseries',
+        'ndmg.nuis',
         'ndmg.scripts'
     ],
     scripts = [
         'ndmg/scripts/ndmg_demo-dwi',
+        'ndmg/scripts/ndmg_demo-func',
         'ndmg/scripts/ndmg_demo-qc'
     ],
     entry_points = {
         'console_scripts': [
+            'fngs_pipeline=ndmg.scripts.fngs_pipeline:main',
             'ndmg_pipeline=ndmg.scripts.ndmg_pipeline:main',
             'ndmg_bids=ndmg.scripts.ndmg_bids:main',
             'ndmg_cloud=ndmg.scripts.ndmg_cloud:main'
@@ -29,8 +33,8 @@ setup(
     },
     version=VERSION,
     description='Neuro Data MRI to Graphs Pipeline',
-    author='Greg Kiar and Will Gray Roncal',
-    author_email='gkiar@jhu.edu, wgr@jhu.edu',
+    author='Greg Kiar, Will Gray Roncal, and Eric Bridgeford',
+    author_email='gkiar@jhu.edu, wgr@jhu.edu, ebridge2@jhu.edu',
     url='https://github.com/neurodata/ndmg',
     download_url='https://github.com/neurodata/ndmg/tarball/' + VERSION,
     keywords=[
@@ -50,5 +54,6 @@ setup(
         'boto3',
         'matplotlib==1.5.1',
         'plotly==1.12',
-    ]
+    ],
+    include_package_data=True,
 )


### PR DESCRIPTION
- [ ] add 2mm atlases to ndmg atlas download. We cannot do 1mm registration yet in a reasonable memory space due to SVD. Workarounds may be possible (ie, FFT instead of PCA, or reduced PCA) but they have not been extensively tested yet. 
- [ ] lateral ventricles mask, MNI mask, and MNI brain added to ndmg atlases package (2mm; required for registration purposes)
- [ ] adjust ndmg_bids.py to use atlases from /ndmg_atlases instead of /FNGS_server (which is part of my docker container and is my link for atlases that I use; once the atlases I need are in ndmg_atlases this won't be necessary though). alternatively, when building the ndmg docker container, also pull my atlases. 

Checking docker container:

```
docker pull ericw95/fngs:0.0.1
# if on cortex
# check functional
docker run -ti -v /braindrive/backups/datasets/BNU1-test:/data ericw95/fngs:0.0.1 /data/ /data/outputs participant -f

# check diffusion
docker run -ti -v /braindrive/backups/datasets/BNU1-test:/data ericw95/fngs:0.0.1 /data/ /data/outputs participant -d

# check both
docker run -ti -v /braindrive/backups/datasets/BNU1-test:/data ericw95/fngs:0.0.1 /data/ /data/outputs participant -f -d
```