### PR TITLE
Fix command name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Currently, functional processing lives only in a development branch, so if you w
 
 You can run our entire end-to-end pipeline in approximately 3 minutes on downsampled data with the following command:
 
-    ndmg_demo-dwi
+    ndmg_demo_dwi
 
 The connectome produced may not have neurological significance, as the data has been significantly downsampled, but this test should ensure that all of the pieces of the code and driver script execute properly. The expected output from the demo is shown below. Files will be downloaded and output data generated in `/tmp/small_demo/` and `/tmp/small_demo/outputs/`, respectively. If the graph properties summarized at the end of the execution below match those observed with your installation, the demo ran successfully.
 


### PR DESCRIPTION
Change `ndmg_demo-dwi` to `ndmg_demo_dwi` in the README