### PR TITLE
change dockerfile pull location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,8 +92,8 @@ RUN \
 
 RUN chmod -R 777 /ndmg_atlases
 
-# Grab ndmg from staging.
-RUN git clone -b staging $NDMG_URL /ndmg && \
+# Grab ndmg from deploy.
+RUN git clone -b deploy $NDMG_URL /ndmg && \
     cd /ndmg && \
     pip3.6 install .
 RUN chmod -R 777 /usr/local/bin/ndmg_bids


### PR DESCRIPTION
very small change.
merging directly into `deploy` because I just built it successfully, there's no way it breaks anything, and it's a big bug (because `dockerhub` is set to autobuild a new version of `neurodata/ndmg_dev:latest` whenever `deploy` gets updated)