### PR TITLE
Xuemin's pull request to nifti_to_png

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,6 @@
 
 
 # ndmg
-
-![Downloads shield](https://img.shields.io/pypi/dm/ndmg.svg)
-[![](https://img.shields.io/pypi/v/ndmg.svg)](https://pypi.python.org/pypi/ndmg)
-![](https://travis-ci.org/neurodata/ndmg.svg?branch=master)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1161284.svg)](https://doi.org/10.5281/zenodo.1161284)
-[![Code Climate](https://codeclimate.com/github/neurodata/ndmg/badges/gpa.svg)](https://codeclimate.com/github/neurodata/ndmg)
-[![DockerHub](https://img.shields.io/docker/pulls/bids/ndmg.svg)](https://hub.docker.com/r/bids/ndmg)
-[![OpenNeuro](http://bids.neuroimaging.io/openneuro_badge.svg)](https://openneuro.org)
-
 ![](./docs/nutmeg.png)
 
 NeuroData's MR Graphs package, **ndmg** (pronounced "***nutmeg***"), is a turn-key pipeline which uses structural and diffusion MRI data to estimate multi-resolution connectomes reliably and scalably.

--- a/ndmg/utils/nifti_to_png.py
+++ b/ndmg/utils/nifti_to_png.py
@@ -22,9 +22,9 @@ import warnings
 
 warnings.simplefilter("ignore")
 from argparse import ArgumentParser
-from scipy.misc import imsave
 import nibabel as nb
 import os
+import imageio
 
 
 def convert(indir, outdir, verbose=False):
@@ -64,7 +64,7 @@ def convert(indir, outdir, verbose=False):
                 for slices in range(dat.shape[2]):
                     if verbose:
                         print("Saving slice:", slices)
-                    imsave(
+                    imageio.imsave(
                         dirname + "/%04d.png" % slices,
                         dat[:, :, slices, count].astype("float32").T,
                     )


### PR DESCRIPTION
The imsave method is deprecated and removed after version 1.3 of SciPy. Using imageio.imsave instead should improve it.