### PR TITLE
Add links to github/pypi on docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,4 +30,10 @@ The ndmg pipeline has been developed as a one-click solution for human connectom
    :caption: Function Reference
    :maxdepth: 1
 
-.. funcref
+.. toctree::
+   :maxdepth: 1
+   :caption: Useful Links
+
+   ndmg @ GitHub <http://www.github.com/neurodata/ndmg/>
+   ndmg @ PyPI <https://pypi.org/project/ndmg/>
+   Issue Tracker <https://github.com/neurodata/ndmg/issues>


### PR DESCRIPTION
Add links to github/pypi in the sidebar of ndmg doc website.