### PR TITLE
Fix and remove outdated badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ![Downloads shield](https://img.shields.io/pypi/dm/ndmg.svg)
 [![PyPI](https://img.shields.io/pypi/v/ndmg.svg)](https://pypi.python.org/pypi/ndmg)
-[![Travis CI](https://travis-ci.org/neurodata/m2g.svg?branch=master)](https://travis-ci.org/github/neurodata/m2g)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1161284.svg)](https://doi.org/10.5281/zenodo.1161284)
+[![Travis CI](https://travis-ci.org/neurodata/m2g.svg?branch=deploy)](https://travis-ci.org/github/neurodata/m2g)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.595684.svg)](https://doi.org/10.5281/zenodo.595684)
 [![Code Climate](https://codeclimate.com/github/neurodata/ndmg/badges/gpa.svg)](https://codeclimate.com/github/neurodata/ndmg)
 [![DockerHub](https://img.shields.io/docker/pulls/bids/ndmg.svg)](https://hub.docker.com/r/bids/ndmg)
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,11 @@
 # ndmg
 
 ![Downloads shield](https://img.shields.io/pypi/dm/ndmg.svg)
-[![](https://img.shields.io/pypi/v/ndmg.svg)](https://pypi.python.org/pypi/ndmg)
-![](https://travis-ci.org/neurodata/ndmg.svg?branch=master)
+[![PyPI](https://img.shields.io/pypi/v/ndmg.svg)](https://pypi.python.org/pypi/ndmg)
+[![Travis CI](https://travis-ci.org/neurodata/m2g.svg?branch=master)](https://travis-ci.org/github/neurodata/m2g)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1161284.svg)](https://doi.org/10.5281/zenodo.1161284)
 [![Code Climate](https://codeclimate.com/github/neurodata/ndmg/badges/gpa.svg)](https://codeclimate.com/github/neurodata/ndmg)
 [![DockerHub](https://img.shields.io/docker/pulls/bids/ndmg.svg)](https://hub.docker.com/r/bids/ndmg)
-[![OpenNeuro](http://bids.neuroimaging.io/openneuro_badge.svg)](https://openneuro.org)
-
-![](./docs/nutmeg.png)
 
 NeuroData's MR Graphs package, **ndmg** (pronounced "**_nutmeg_**"), is a turn-key pipeline which uses structural and diffusion MRI data to estimate multi-resolution connectomes reliably and scalably.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ndmg
 
-![Downloads shield](https://img.shields.io/pypi/dm/ndmg.svg)
-[![PyPI](https://img.shields.io/pypi/v/ndmg.svg)](https://pypi.python.org/pypi/ndmg)
+![Downloads shield](https://img.shields.io/pypi/dm/m2g.svg)
+[![PyPI](https://img.shields.io/pypi/v/m2g.svg)](https://pypi.python.org/pypi/m2g)
 [![Travis CI](https://travis-ci.org/neurodata/m2g.svg?branch=deploy)](https://travis-ci.org/github/neurodata/m2g)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.595684.svg)](https://doi.org/10.5281/zenodo.595684)
 [![Code Climate](https://codeclimate.com/github/neurodata/ndmg/badges/gpa.svg)](https://codeclimate.com/github/neurodata/ndmg)


### PR DESCRIPTION
- The `travis` badge was still directing to old repo name.
- The `OpenNeuro` badge was removed from the `BIDS` website, and here is its current position: https://github.com/bids-standard/bids-website/blob/gh-pages/old_website/openneuro_badge.svg
- The `nutmeg` image file was removed in [this commit](https://github.com/neurodata/m2g/commit/7ca9977429690574a335bfffba08fe5ff28b8154#diff-46b42b4229cd7a39c564e780bb665a8bde4fdf722007e8473f167fe53ed4b995).